### PR TITLE
(chg) Improve Dockerfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.6.0'
+ruby '2.6.3'
 
 gem 'watir'
 gem 'selenium-webdriver'

--- a/checks/http/content/content.rb
+++ b/checks/http/content/content.rb
@@ -92,7 +92,7 @@ class Content < Intrigue::Ident::Check::Base
         :name =>"Email Addresses Detected",
         :match_type => :content_title,
         :dynamic_result => lambda { |d| 
-        email_address_regex = /([a-zA-Z0-9_\-\.]+@[a-zA-Z0-9_\-\.]+\.[a-zA-Z]{2,5})/
+        email_address_regex = /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
           captures = _all_body_captures(d,email_address_regex) || []
           captures.select{|e| !(e =~ /\.png$/) }.compact
         },


### PR DESCRIPTION
This change moves the Dockerfile base image from Alpine Linux
to Debian Buster.
Debian Buster comes with Ruby 2.5 by default which is not what
we want, so I ended up building Ruby 2.6 from source thus
requiring updates to the Gemfile.


```
docker run --name idents retornam/ident:latest -v -u https://example.com:443
Checking... https://example.com:443
Fingerprint:
Content Checks:
 - Google Analytics Account Detected: false
 - Location Header:
 - Directory Listing Detected: false
 - Form Detected: false
 - File Upload Form Detected: false
 - Email Addresses Detected: []
 - Access-Control-Allow-Origin Header: false
 - P3P Header: false
 - X-Frame-Options Header: false
 - X-XSS-Protection Header: false
 - Authentication - HTTP: false
 - Authentication - Session Identifier: false
```
@jcran 