### PR TITLE
Add checks/http/glimpse.rb

### DIFF
--- a/checks/http/glimpse.rb
+++ b/checks/http/glimpse.rb
@@ -1,0 +1,32 @@
+module Intrigue
+module Ident
+module Check
+    class Glimpse < Intrigue::Ident::Check::Base
+
+      def generate_checks(url)
+        [
+          {
+            :type => "fingerprint",
+            :category => "application",
+            :tags => ["Web Framework"],
+            :vendor => "Glimpse",
+            :product => "Glimpse",
+            :match_details => "glimpse.axd version",
+            :version => nil,
+            :references => [
+              "https://docs.microsoft.com/en-us/aspnet/mvc/overview/performance/profile-and-debug-your-aspnet-mvc-app-with-glimpse"
+            ],
+            :dynamic_version => lambda { |x| 
+              _first_body_capture(x,/name="glimpseRuntimeVersion" value="([\d\.]*)"/) 
+            },
+            :match_type => :content_body,
+            :match_content => /Glimpse - Configuration Page/,
+            :paths => ["#{url}/glimpse.axd"], 
+            :inference => true
+          }
+        ]
+      end
+    end
+end
+end
+end


### PR DESCRIPTION
This checks for Glimpse plugin and retrieves the version.

Glimpse plugin can reveal a lot of juicy application debugging info and system information - but that hasn't been implemented in this PR.

The presence of Glimpse also implies the presence of ASP.NET - but this PR doesn't report ASP.NET.
