### PR TITLE
adjust output for non-http fingerprinters to include banner (separate…

### DIFF
--- a/lib/ftp/ftp.rb
+++ b/lib/ftp/ftp.rb
@@ -24,7 +24,7 @@ module Intrigue
           results << match_smtp_response_hash(check,details)
         end
   
-      results.map{|x| (x || {}).merge({"banner" => banner_string})}.uniq.compact
+      { "fingerprints" => results.uniq.compact, "banner" => banner_string, "content" => [] }
       end
 
 

--- a/lib/smtp/smtp.rb
+++ b/lib/smtp/smtp.rb
@@ -24,7 +24,7 @@ module Intrigue
           results << match_smtp_response_hash(check,details)
         end
   
-      results.map{|x| (x || {}).merge({"banner" => banner_string})}.uniq.compact
+      { "fingerprints" => results.uniq.compact, "banner" => banner_string, "content" => [] }
       end
 
       private

--- a/lib/snmp/snmp.rb
+++ b/lib/snmp/snmp.rb
@@ -26,7 +26,7 @@ module Intrigue
           results << match_snmp_response_hash(check,details)
         end
 
-      results.map{|x| (x || {}).merge({"banner" => banner_string})}.uniq.compact
+      { "fingerprints" => results.uniq.compact, "banner" => banner_string, "content" => [] }
       end
 
       private

--- a/lib/ssh/ssh.rb
+++ b/lib/ssh/ssh.rb
@@ -24,7 +24,7 @@ module Intrigue
           results << match_ssh_response_hash(check,details)
         end
   
-      results.map{|x| (x || {}).merge({"banner" => banner_string})}.uniq.compact
+      { "fingerprints" => results.uniq.compact, "banner" => banner_string, "content" => [] }
       end
 
       private

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Ident
-  VERSION = "0.9.3"
+  VERSION = "0.9.4"
 end


### PR DESCRIPTION
Introduces a change in the output of the SSH, SMTP, SNMP, TELNET, FTP fingerprinters - specifically introducing a section for content (in the future) to stay at parity with the HTTP fingerprinter, and separates out the banner
