### PR TITLE
add support for telnet fingerprinting

### DIFF
--- a/checks/telnet/base.rb
+++ b/checks/telnet/base.rb
@@ -1,0 +1,16 @@
+module Intrigue
+  module Ident
+  module TelnetCheck
+  class Base
+  
+    include Intrigue::Ident::BannerHelpers
+  
+    def self.inherited(base)
+      Intrigue::Ident::Telnet::CheckFactory.register(base)
+    end
+  
+  end
+  end
+  end
+  end
+  

--- a/checks/telnet/huawei.rb
+++ b/checks/telnet/huawei.rb
@@ -1,0 +1,26 @@
+module Intrigue
+module Ident
+module TelnetCheck
+  class Huawei < Intrigue::Ident::TelnetCheck::Base
+    def generate_checks
+      [
+        {
+          :type => "fingerprint",
+          :category => "operating_system",
+          :tags => ["Telnet Server"],
+          :vendor => "Huawei",
+          :product => "Home Gateway",
+          :references => [],
+          :version => nil,
+          :match_type => :content_banner,
+          :match_content => /Welcome Visiting Huawei Home Gateway/i,
+          :match_details => "banner",
+          :hide => false,
+          :inference => false
+        }
+      ]
+    end
+  end
+end
+end
+end

--- a/lib/ident.rb
+++ b/lib/ident.rb
@@ -8,6 +8,10 @@ require 'zlib'
 require_relative 'utils'
 require_relative 'version'
 
+###
+### Start protocol requires 
+###
+
 ##################################
 # Load in http matchers and checks
 ###################################
@@ -75,7 +79,7 @@ Dir["#{check_folder}/*.rb"].each { |file| require_relative file }
 
 
 ##################################
-# Load in snmp matchers and checks
+# Load in ssh matchers and checks
 ##################################
 require_relative 'ssh/matchers'
 include Intrigue::Ident::Ssh::Matchers
@@ -83,10 +87,27 @@ include Intrigue::Ident::Ssh::Matchers
 require_relative 'ssh/check_factory'
 require_relative '../checks/ssh/base'
 
-# snmp fingerprints
+# ssh fingerprints
 check_folder = File.expand_path('../checks/ssh', File.dirname(__FILE__)) # get absolute directory
 Dir["#{check_folder}/*.rb"].each { |file| require_relative file }
 
+##################################
+# Load in telnet matchers and checks
+##################################
+require_relative 'telnet/matchers'
+include Intrigue::Ident::Telnet::Matchers
+
+require_relative 'telnet/check_factory'
+require_relative '../checks/telnet/base'
+
+# telnet fingerprints
+check_folder = File.expand_path('../checks/telnet', File.dirname(__FILE__)) # get absolute directory
+Dir["#{check_folder}/*.rb"].each { |file| require_relative file }
+
+
+###
+### End protocol requires 
+###
 
 # Load vulndb client 
 require_relative "vulndb_client"

--- a/lib/telnet/check_factory.rb
+++ b/lib/telnet/check_factory.rb
@@ -1,0 +1,24 @@
+module Intrigue
+module Ident
+module Telnet
+class CheckFactory
+
+    #
+    # Register a new handler
+    #
+    def self.register(klass)
+      @checks = [] unless @checks
+      @checks << klass if klass
+    end
+
+    #
+    # Provide the full list of checks
+    #
+    def self.checks
+      @checks
+    end
+
+end
+end
+end
+end

--- a/lib/telnet/content.rb
+++ b/lib/telnet/content.rb
@@ -1,0 +1,13 @@
+module Intrigue
+  module Ident
+    module Telnet
+      module Content
+
+      def _banner(content)
+        content["details"]["banner"]
+      end
+
+    end
+  end
+end
+end

--- a/lib/telnet/matchers.rb
+++ b/lib/telnet/matchers.rb
@@ -1,0 +1,26 @@
+module Intrigue
+module Ident
+module Telnet
+module Matchers
+
+  require_relative 'telnet'
+  include Intrigue::Ident::Telnet
+  
+  require_relative 'content'
+  include Intrigue::Ident::Telnet::Content
+
+  def match_telnet_response_hash(check,response_hash)
+    
+    if check[:type] == "fingerprint"
+      if check[:match_type] == :content_banner
+        puts "Banner: #{_banner(response_hash)}"
+        match = _construct_match_response(check,response_hash) if (_banner(response_hash) =~ check[:match_content])
+      end
+    end
+
+  end
+
+end
+end
+end
+end

--- a/lib/telnet/telnet.rb
+++ b/lib/telnet/telnet.rb
@@ -1,0 +1,52 @@
+module Intrigue
+  module Ident
+    module Telnet
+
+      include Intrigue::Ident::SimpleSocket
+
+      def generate_telnet_request_and_check(ip, port=23, debug=false)
+
+        # do the request (store as string and funky format bc of usage in core.. and  json conversions)
+        banner_string = grab_banner_telnet(ip,port)
+        details = {
+          "details" => {
+            "banner" => banner_string
+          }
+        }
+  
+        results = []
+  
+        # generate the checks 
+        checks = Intrigue::Ident::Telnet::CheckFactory.checks.map{ |x| x.new.generate_checks }.compact.flatten
+  
+        # and run them against our result
+        checks.each do |check|
+          results << match_telnet_response_hash(check,details)
+        end
+  
+      { "fingerprints" => results.uniq.compact, "banner" => banner_string, "content" => [] }
+      end
+
+      private
+
+      def grab_banner_telnet(ip, port, timeout=30)
+          
+        if socket = connect_tcp(ip, port, timeout)
+          #socket.writepartial("HELO friend.local\r\n\r\n")
+          begin 
+            out = socket.readpartial(2048, timeout: timeout)
+          rescue Socketry::TimeoutError
+            puts "Error while reading! Timeout."
+            out = nil
+          end
+        else 
+          out = nil
+        end
+        
+      out
+      end
+
+
+    end
+  end
+end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Ident
-  VERSION = "0.9.4"
+  VERSION = "0.9.5"
 end

--- a/util/ident.rb
+++ b/util/ident.rb
@@ -29,6 +29,8 @@ def check_single_ip(opts)
     results = generate_smtp_request_and_check(ip, port || 25)
   elsif  opts[:proto] == "ssh"
     results = generate_ssh_request_and_check(ip, port || 22)
+  elsif  opts[:proto] == "telnet"
+    results = generate_telnet_request_and_check(ip, port || 23)
   else 
     puts "Error! Unknown protocol!"
     puts "We know about the following: #{allowed_protocols.join(", ")}"


### PR DESCRIPTION
Adds support for fingerprinting on Telnet bannners. Usage:

```$ bundle exec ./util/ident.rb --ip 189.203.175.243 --proto telnet
Banner: ??????
Welcome Visiting Huawei Home Gateway
Copyright by Huawei Technologies Co., Ltd.

Login:
Got Results:
{"fingerprints"=>[{"type"=>"fingerprint", "vendor"=>"Huawei", "product"=>"Home Gateway", "version"=>"", "update"=>"", "tags"=>["Telnet Server"], "match_type"=>:content_banner, "match_details"=>"banner", "hide"=>false, "cpe"=>"cpe:2.3:o:huawei:home_gateway::", "issue"=>nil, "task"=>nil, "inference"=>false}], "banner"=>"\xFF\xFB\x01\xFF\xFB\x03\xFF\xFB\x18\r\nWelcome Visiting Huawei Home Gateway\r\nCopyright by Huawei Technologies Co., Ltd.\r\n\r\nLogin:", "content"=>[]}
```