### PR TITLE
Integrate Recog for additional fingerprints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby '2.6.5'
 
 gem 'pry'
 gem 'socketry'
+gem 'recog-intrigue',         :git => 'https://github.com/intrigueio/recog.git'
 gem 'slop'
 gem 'snmp'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/intrigueio/recog.git
+  revision: e8247496cac875060f498f327cbc8ce0a10cee7f
+  specs:
+    recog-intrigue (2.3.7)
+      nokogiri
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -6,6 +13,9 @@ GEM
     hitimes (1.3.1)
     json (2.3.0)
     method_source (0.9.2)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.9)
+      mini_portile2 (~> 2.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -26,6 +36,7 @@ PLATFORMS
 DEPENDENCIES
   json
   pry
+  recog-intrigue!
   rspec-core
   rspec-expectations
   slop

--- a/lib/ident.rb
+++ b/lib/ident.rb
@@ -180,6 +180,7 @@ module Intrigue
         end
 
         to_return = {
+          "method" => "ident",
           "type" => check[:type],
           "vendor" => check[:vendor],
           "product" => check[:product],

--- a/lib/ident.rb
+++ b/lib/ident.rb
@@ -8,6 +8,9 @@ require 'zlib'
 require_relative 'utils'
 require_relative 'version'
 
+# integrate recog
+require_relative 'recog'
+
 ###
 ### Start protocol requires 
 ###
@@ -103,7 +106,6 @@ require_relative '../checks/telnet/base'
 # telnet fingerprints
 check_folder = File.expand_path('../checks/telnet', File.dirname(__FILE__)) # get absolute directory
 Dir["#{check_folder}/*.rb"].each { |file| require_relative file }
-
 
 ###
 ### End protocol requires 
@@ -253,6 +255,8 @@ module Intrigue
 
 end
 end
+
+
 
 # always include 
 include Intrigue::Ident

--- a/lib/recog.rb
+++ b/lib/recog.rb
@@ -1,0 +1,38 @@
+require 'recog'
+
+module Intrigue
+module Ident
+module Recog
+
+module Http
+  
+  def recog_match_http_server_banner(banner)
+    options = OpenStruct.new(color: false, detail: true, fail_fast: false, multi_match: true)
+    ndb = ::Recog::DB.new("http_servers.xml");nil
+    options.fingerprints = ndb.fingerprints;nil
+    matcher = ::Recog::MatcherFactory.build(options);nil
+    matcher.match_banner(banner.gsub("server:","").strip)
+  end
+
+  def recog_match_http_cookies(string)
+    options = OpenStruct.new(color: false, detail: true, fail_fast: false, multi_match: true)
+    ndb = ::Recog::DB.new("http_cookies.xml");nil
+    options.fingerprints = ndb.fingerprints;nil
+    matcher = ::Recog::MatcherFactory.build(options);nil
+    matcher.match_banner(string.gsub("set-cookie:","").strip)
+  end
+end
+
+module Smtp
+  def recog_match_smtp_banner(string)
+    options = OpenStruct.new(color: false, detail: true, fail_fast: false, multi_match: true)
+    ndb = ::Recog::DB.new("smtp_banners.xml");nil
+    options.fingerprints = ndb.fingerprints;nil
+    matcher = ::Recog::MatcherFactory.build(options);nil
+    matcher.match_banner(string)
+  end
+end
+
+end
+end
+end

--- a/lib/recog.rb
+++ b/lib/recog.rb
@@ -4,14 +4,39 @@ module Intrigue
 module Ident
 module Recog
 
+module Helpers
+
+  def recog_to_ident_hash(recog_hash)
+
+    # do the field conversation 
+    out = {}
+    out["method"] = "recog"
+    out["vendor"] = recog_hash["service.vendor"]
+    out["product"] = recog_hash["service.product"]
+    out["version"] = recog_hash["service.version"]
+    out["cpe"] = recog_hash["service.cpe23"]
+    out["match_details"] = "#{recog_hash["matched"]} (Recog: #{recog_hash["fingerprint_db"]})"
+    out["inference"] = false
+    out["hide"] = false
+    out["issue"] = nil
+
+  out
+  end
+
+end
+
 module Http
-  
+  include Intrigue::Ident::Recog::Helpers
+
   def recog_match_http_server_banner(banner)
     options = OpenStruct.new(color: false, detail: true, fail_fast: false, multi_match: true)
     ndb = ::Recog::DB.new("http_servers.xml");nil
     options.fingerprints = ndb.fingerprints;nil
     matcher = ::Recog::MatcherFactory.build(options);nil
-    matcher.match_banner(banner.gsub("server:","").strip)
+    matches = matcher.match_banner(banner.gsub("server:","").strip)
+
+    # now convert a match to ident match format
+    matches.compact.map {|m| recog_to_ident_hash(m)}
   end
 
   def recog_match_http_cookies(string)
@@ -19,17 +44,24 @@ module Http
     ndb = ::Recog::DB.new("http_cookies.xml");nil
     options.fingerprints = ndb.fingerprints;nil
     matcher = ::Recog::MatcherFactory.build(options);nil
-    matcher.match_banner(string.gsub("set-cookie:","").strip)
+    matches = matcher.match_banner(string.gsub("set-cookie:","").strip)
+
+    # now convert it 
+    matches.map {|m| recog_to_ident_hash(m)}
   end
 end
 
 module Smtp
+  include Intrigue::Ident::Recog::Helpers
   def recog_match_smtp_banner(string)
     options = OpenStruct.new(color: false, detail: true, fail_fast: false, multi_match: true)
     ndb = ::Recog::DB.new("smtp_banners.xml");nil
     options.fingerprints = ndb.fingerprints;nil
     matcher = ::Recog::MatcherFactory.build(options);nil
-    matcher.match_banner(string)
+    matches = matcher.match_banner(string)
+
+    # now convert it 
+    matches.map {|m| recog_to_ident_hash(m)}
   end
 end
 

--- a/lib/smtp/matchers.rb
+++ b/lib/smtp/matchers.rb
@@ -8,6 +8,9 @@ module Matchers
   
   require_relative 'content'
   include Intrigue::Ident::Smtp::Content
+  
+  # gives us the recog smtp matchers 
+  include Intrigue::Ident::Recog::Smtp
 
   def match_smtp_response_hash(check,response_hash)
   

--- a/lib/smtp/smtp.rb
+++ b/lib/smtp/smtp.rb
@@ -23,8 +23,10 @@ module Intrigue
         checks.each do |check|
           results << match_smtp_response_hash(check,details)
         end
+
+        recog_results = recog_match_smtp_banner(banner_string)
   
-      { "fingerprints" => results.uniq.compact, "banner" => banner_string, "content" => [] }
+      { "fingerprints" => results.uniq.compact, "banner" => banner_string, "recog" => recog_results, "content" => [] }
       end
 
       private

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Ident
-  VERSION = "0.9.5"
+  VERSION = "0.9.9"
 end


### PR DESCRIPTION
Integrates and runs Rapid7's pattern matching lib "Recog" (https://github.com/rapid7/recog) as part of the normal Ident run. Only HTTP Cookies and Server Headers are currently supported, but this lays the groundwork to support other network services - which is where the true benefit is. 

An example, requesting a page and returning the fingerprints. Considered keeping the results separate but having them under the returned 'fingerprint' attribute can give us vulnerability version based inference with no additional work - provided the checks are specific enough and handle backporting (which is a tall order). We shall see. 

```
JSON.pretty_generate(generate_http_requests_and_check("https://www.test.com")["fingerprint"])
[
  {
    "method": "ident",
    "type": "fingerprint",
    "vendor": "Nginx",
    "product": "Nginx",
    "version": "",
    "update": "",
    "tags": [
      "Web Server"
    ],
    "match_type": "content_headers",
    "match_details": "Nginx (no version)",
    "hide": false,
    "cpe": "cpe:2.3:a:nginx:nginx::",
    "issue": null,
    "task": null,
    "inference": false
  },
  {
    "method": "ident",
    "type": "fingerprint",
    "vendor": "Google",
    "product": "Tag Manager",
    "version": "",
    "update": "",
    "tags": [
      "Marketing",
      "Javascript"
    ],
    "match_type": "content_body",
    "match_details": "js load string",
    "hide": false,
    "cpe": "cpe:2.3:a:google:tag_manager::",
    "issue": null,
    "task": null,
    "inference": false
  },
  {
    "method": "ident",
    "type": "fingerprint",
    "vendor": "Bootstrap",
    "product": "Bootstrap",
    "version": "",
    "update": "",
    "tags": [
      "Web Framework"
    ],
    "match_type": "content_body",
    "match_details": "boostrap css",
    "hide": false,
    "cpe": "cpe:2.3:a:bootstrap:bootstrap::",
    "issue": null,
    "task": null,
    "inference": false
  },
  {
    "method": "recog",
    "vendor": "nginx",
    "product": "nginx",
    "version": null,
    "cpe": "cpe:/a:nginx:nginx:-",
    "match_details": "nginx without version info (Recog: http_header.server)",
    "inference": false,
    "hide": false,
    "issue": null
  },
  {
    "method": "recog",
    "vendor": "nginx",
    "product": "nginx",
    "version": null,
    "cpe": "cpe:/a:nginx:nginx:-",
    "match_details": "nginx with version info and/or mods (Recog: http_header.server)",
    "inference": false,
    "hide": false,
    "issue": null
  }
]
=> nil
```