### PR TITLE
support JS component version detection

### DIFF
--- a/checks/http/javascript/jquery.rb
+++ b/checks/http/javascript/jquery.rb
@@ -1,0 +1,28 @@
+module Intrigue
+module Ident
+module Check
+module Javascript 
+class Jquery < Intrigue::Ident::Check::Base
+  def generate_checks(url)
+    [    
+      {
+        :type => "fingerprint",
+        :category => "application",
+        :tags => ["Javascript"],
+        :vendor => "JQuery",
+        :product =>"JQuery",
+        :match_details =>"version in file",
+        :match_type => :content_body,
+        :match_content =>  /jQuery v\d\.\d\.\d \| \(c\) JS Foundation and other contributors/i,
+        :dynamic_version => lambda {|x| 
+          _first_body_capture(x,/jQuery v(\d\.\d\.\d) \| \(c\) JS Foundation and other contributors/i) },
+        :paths => ["#{url}"],
+        :inference => false
+      }
+    ]
+  end
+end
+end
+end
+end
+end

--- a/lib/ident.rb
+++ b/lib/ident.rb
@@ -36,6 +36,10 @@ Dir["#{content_check_folder}/*.rb"].each { |file| require_relative file }
 content_check_folder = File.expand_path('../checks/http/wordpress', File.dirname(__FILE__)) # get absolute directory
 Dir["#{content_check_folder}/*.rb"].each { |file| require_relative file }
 
+# http content, javascript specific checks
+content_check_folder = File.expand_path('../checks/http/javascript', File.dirname(__FILE__)) # get absolute directory
+Dir["#{content_check_folder}/*.rb"].each { |file| require_relative file }
+
 # General helpers (apply widely across protocols)
 
 require_relative 'simple_socket'


### PR DESCRIPTION
Adds a new subsection of checks specifically designed for JS components. JQuery is the only component currently supported. 