### PR TITLE
Fix typo check_file_urls -> check_file_uris

### DIFF
--- a/util/ident.rb
+++ b/util/ident.rb
@@ -6,7 +6,7 @@ require 'thread'
 include Intrigue::Ident
 include Intrigue::Ident::Utils
 
-def check_file_urls(opts)
+def check_file_uris(opts)
 
   filepath = opts[:file]
   debug = opts[:debug]


### PR DESCRIPTION
Otherwise, the `--file` option doesn't work.