### PR TITLE
Added FP checks for latest updates of Microsoft Exchange 2016 & 2019

### DIFF
--- a/checks/http/microsoft.rb
+++ b/checks/http/microsoft.rb
@@ -2,7 +2,7 @@ module Intrigue
   module Ident
   module Check
   class Microsoft < Intrigue::Ident::Check::Base
-  
+
     def generate_checks(url)
       [
         {
@@ -15,7 +15,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_title,
           :match_content =>  /Home Page - My ASP.NET Application/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -28,7 +28,7 @@ module Intrigue
           :match_type => :content_cookies,
           :match_content =>  /AspNetCore.Antiforgery/i,
           :match_details =>"ASP.Net Antiforgery cookie",
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -38,12 +38,12 @@ module Intrigue
           :vendor => "Microsoft",
           :product =>"ASP.NET",
           :version => nil,
-          :dynamic_version => lambda{|x| 
+          :dynamic_version => lambda{|x|
             _first_body_capture(x,/ASP.NET Version:\ ([\d\.]*)/i)},
           :match_type => :content_body,
           :match_content =>  /^.*ASP.NET is configured*$/i,
           :match_details =>"ASP.Net Error Message",
-          :paths => ["#{url}", "#{url}/doesntexist-123" ], 
+          :paths => ["#{url}", "#{url}/doesntexist-123" ],
           :inference => false
         },
         {
@@ -53,12 +53,12 @@ module Intrigue
           :vendor => "Microsoft",
           :product =>"ASP.NET",
           :version => nil,
-          :dynamic_version => lambda{ |x| 
+          :dynamic_version => lambda{ |x|
             _first_header_capture(x,/^x-aspnet-version:\ ([\d\.]*)/i) },
           :match_type => :content_headers,
           :match_content =>  /^x-aspnet-version:.*$/i,
           :match_details =>"X-AspNet Header",
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -71,7 +71,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_cookies,
           :match_content =>  /ASPSESSIONID.*$/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -84,7 +84,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_cookies,
           :match_content =>  /ASP.NET_SessionId.*$/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -100,7 +100,7 @@ module Intrigue
           ],
           :match_type => :content_cookies,
           :match_content =>  /ASPXAUTH=/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -111,11 +111,11 @@ module Intrigue
           :product =>"ASP.NET MVC",
           :match_details =>"ASP.Net MVC Header",
           :version => nil,
-          :dynamic_version => lambda{ |x| 
+          :dynamic_version => lambda{ |x|
             _first_header_capture(x,/^x-aspnetmvc-version:\s([\d\.]+)/i) },
           :match_type => :content_headers,
           :match_content =>  /x-aspnetmvc-version/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => true
         },
         #{
@@ -127,11 +127,11 @@ module Intrigue
         #  :product =>"ASP.NET Core",
         #  :match_details =>"Asp.Net MVC Header",
         #  :version => nil,
-        #  :dynamic_version => lambda{ |x| 
+        #  :dynamic_version => lambda{ |x|
         #    _first_header_capture(x,/^x-aspnetmvc-version:\s([\d\.]+)/i) },
         #  :match_type => :content_headers,
         #  :match_content => /x-aspnetmvc-version/i,
-        #  :paths => ["#{url}"], 
+        #  :paths => ["#{url}"],
         #  :inference => true
         #},
         {
@@ -144,7 +144,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_body,
           :match_content =>  /WebResource.axd?d=/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -157,7 +157,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_body,
           :match_content =>  /__VIEWSTATEGENERATOR/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -169,12 +169,12 @@ module Intrigue
           :product =>".NET Framework",
           :match_details => "trace.axd version",
           :version => nil,
-          :dynamic_version => lambda { |x| 
-            _first_body_capture(x,/ASP.NET Version:([\d\.]*)/) 
+          :dynamic_version => lambda { |x|
+            _first_body_capture(x,/ASP.NET Version:([\d\.]*)/)
           },
           :match_type => :content_body,
           :match_content =>  /Microsoft \.NET Framework Version/i,
-          :paths => ["#{url}/Trace.axd"], 
+          :paths => ["#{url}/Trace.axd"],
           :require_product => "ASP.NET",
           :inference => true
         },
@@ -188,7 +188,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_title,
           :match_content =>  /^Microsoft Azure Web App - Error 404$/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :hide => true,
           :inference => false
         },
@@ -202,7 +202,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /^x-msedge-ref:.*/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -214,7 +214,7 @@ module Intrigue
           :match_details => "proxy default error",
           :match_type => :content_body,
           :match_content =>  /<h2>Our services aren\'t available right now<\/h2><p>We\'re working to restore all services as soon as possible. Please check back soon/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :hide => true,
           :inference => false
         },
@@ -228,7 +228,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /^x-ms-ref:.*/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -241,7 +241,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content => /^x-ms-request-id:.*/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -254,7 +254,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_cookies,
           :match_content => /ApplicationGatewayAffinity=/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -267,7 +267,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_cookies,
           :match_content => /ApplicationGatewayAffinityCORS=/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -277,13 +277,13 @@ module Intrigue
           :vendor => "Microsoft",
           :product => "Verizon Azure CDN",
           :references => [
-            "https://docs.microsoft.com/en-us/azure/cdn/cdn-verizon-http-headers", 
+            "https://docs.microsoft.com/en-us/azure/cdn/cdn-verizon-http-headers",
             "https://docs.vdms.com/cdn/Content/HTTP_and_HTTPS_Data_Delivery/Response.htm"
           ],
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /^server:\ (ECAcc|ECD|EOS|ECS)\ \([a-zA-Z]{3}\/[a-zA-Z0-9]{4}\)$/i,
-          :dynamic_version => lambda { |x| 
+          :dynamic_version => lambda { |x|
             _first_header_capture(x,/^server:\ (ECAcc|ECD|EOS|ECS)\ \([a-zA-Z]{3}\/[a-zA-Z0-9]{4}\)$/i) },
           :hide => false,
           :paths => ["#{url}"],
@@ -299,7 +299,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /^X-Powered-By: ASP.NETs$/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -312,7 +312,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /commerce-server-software: Microsoft Commerce Server.*/,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -326,7 +326,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /^x-feserver:.*$/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -340,7 +340,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /^location:.*\/owa\/$/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -361,7 +361,7 @@ module Intrigue
             update_string = _first_header_capture(x, /^x-owa-version:(.*)$/i)
             owa_to_exchange_version(update_string)[:update]
           },
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => true
         },
         {
@@ -383,13 +383,13 @@ module Intrigue
             owa_to_exchange_version(version_string)[:version]
           },
           :dynamic_update => lambda { |x|
-            
+
             update_string = _first_body_capture(x, /href=\"\/owa\/auth\/([\d\.]+)\/themes\/resources\/favicon.ico/)
             update_string = _first_body_capture(x, /href=\"\/owa\/([\d\.]+)\/themes\/resources\/favicon.ico/) unless update_string
-            
+
             owa_to_exchange_version(update_string)[:update]
           },
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => true # TODO - not specific enough yet
         },
         {
@@ -411,13 +411,13 @@ module Intrigue
             owa_to_exchange_version(version_string)[:version]
           },
           :dynamic_update => lambda { |x|
-            
+
             update_string = _first_body_capture(x, /href=\"\/owa\/auth\/([\d\.]+)\/themes\/resources\/favicon.ico/)
             update_string = _first_body_capture(x, /href=\"\/owa\/([\d\.]+)\/themes\/resources\/favicon.ico/) unless update_string
-            
+
             owa_to_exchange_version(update_string)[:update]
           },
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => true # TODO - not specific enough yet
         },
         {
@@ -430,8 +430,8 @@ module Intrigue
           :version => nil,
           :match_type => :content_cookies,
           :match_content =>  /<title>Microsoft Forefront TMG/,
-          :paths => ["#{url}"], 
-          :inference => false 
+          :paths => ["#{url}"],
+          :inference => false
         },
         {
           :type => "fingerprint",
@@ -443,8 +443,8 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /via:\ 1.1\ TMGSRVR/,
-          :paths => ["#{url}"], 
-          :inference => false 
+          :paths => ["#{url}"],
+          :inference => false
         },
         {
           :type => "fingerprint",
@@ -456,8 +456,8 @@ module Intrigue
           :match_type => :content_title,
           :match_content =>  /^Microsoft ISA Server 2006$/i,
           :match_details =>"standard title",
-          :paths => ["#{url}"], 
-          :inference => false 
+          :paths => ["#{url}"],
+          :inference => false
         },
         {
           :type => "fingerprint",
@@ -472,7 +472,7 @@ module Intrigue
           :dynamic_version => lambda { |x|
             _first_header_capture(x,/^.*FrontPage\/([\d\.]*).*$/i)
           },
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => true
         },
         {
@@ -484,7 +484,7 @@ module Intrigue
           :match_details =>"server header",
           :match_type => :content_headers,
           :match_content =>  /server: Microsoft-IIS/,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false # not specific enough
         },
         {
@@ -500,7 +500,7 @@ module Intrigue
           },
           :match_type => :content_headers,
           :match_content =>  /server: Microsoft-IIS\//,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false # not specific enough
         },
         {
@@ -513,7 +513,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_body,
           :match_content =>  /401.2 - Unauthorized: Access is denied due to server configuration.<br>Internet Information Services \(IIS\)/,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false # not specific enough
         },
         {
@@ -526,7 +526,7 @@ module Intrigue
           :version => "8.0",
           :match_type => :content_body,
           :match_content =>  /<img src=\"iis-8.png\"/,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false # not specific enough
         },
         {
@@ -539,7 +539,7 @@ module Intrigue
           :version => "8.5",
           :match_type => :content_body,
           :match_content =>  /<img src=\"iis-85.png\"/,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false # not specific enough
         },
         {
@@ -552,7 +552,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /server: Microsoft-HTTPAPI\/2.0/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -566,7 +566,7 @@ module Intrigue
           :match_type => :content_body,
           :hide => true,
           :match_content =>  /Error Code: 403 Forbidden. The server denied the specified Uniform Resource Locator \(URL\)/,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -580,7 +580,7 @@ module Intrigue
           :match_type => :content_body,
           :hide => true,
           :match_content =>  /HTTP Error 404. The requested resource is not found./,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -594,7 +594,7 @@ module Intrigue
           :match_type => :content_body,
           :hide => true,
           :match_content =>  /403 Forbidden. The server denied the specified Uniform Resource Locator (URL)/,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -608,7 +608,7 @@ module Intrigue
           :match_type => :content_body,
           :hide => true,
           :match_content =>  /HTTP Error 503. The service is unavailable./,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -622,7 +622,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /server: Kestrel/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -635,7 +635,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /x-ms-server-fqdn/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -648,7 +648,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_cookies,
           :match_content =>  /x-ms-gateway-slice/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -661,10 +661,10 @@ module Intrigue
           :version => nil,
           :match_type => :content_body,
           :match_content =>  /ok3static.oktacdn.com\/assets\/img\/logos\/office365/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
-        
+
         {
           :type => "fingerprint",
           :category => "service",
@@ -675,7 +675,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_title,
           :match_content =>  /Sign in to Outlook/i,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -688,7 +688,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /location: \/owa/,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -701,9 +701,9 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /x-owa-version/,
-          :dynamic_version => lambda { |x| 
+          :dynamic_version => lambda { |x|
             _first_header_capture(x, /x-owa-version:(.*)/) },
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => true
         },
         {
@@ -716,9 +716,9 @@ module Intrigue
           :version => nil,
           :match_type => :content_body,
           :match_content =>  /OwaPage\ =\ ASP.auth_logon_aspx/,
-          :dynamic_version => lambda { |x| 
+          :dynamic_version => lambda { |x|
             _first_body_capture x, /href=\"\/owa\/auth\/(.*)\/themes\/resources\/favicon.ico/ },
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => true
         },
         {
@@ -731,7 +731,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_title ,
           :match_content =>  /^Outlook Web App$/,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -744,7 +744,7 @@ module Intrigue
           :version => nil,
           :match_type => :conent_headers ,
           :match_content =>  /^Location: https:\/\/.*\/owa\/$/,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -757,11 +757,11 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /microsoftsharepointteamservices/,
-          :dynamic_version => lambda { |x| 
+          :dynamic_version => lambda { |x|
             sharepoint_server_version_from_team_services(_first_header_capture(x,/^microsoftsharepointteamservices:(.*)/i))[:version] },
-          :dynamic_update => lambda { |x| 
+          :dynamic_update => lambda { |x|
             sharepoint_server_version_from_team_services(_first_header_capture(x,/^microsoftsharepointteamservices:(.*)/i))[:update] },
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -789,9 +789,9 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /sprequestguid/,
-          :dynamic_version => lambda { |x| 
+          :dynamic_version => lambda { |x|
             _first_header_capture(x,/^microsoftsharepointteamservices:(.*)/i) },
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => true
         },
         {
@@ -804,9 +804,9 @@ module Intrigue
           :version => nil,
           :match_type => :content_headers,
           :match_content =>  /^microsoftsharepointteamservices:.*$/,
-          :dynamic_version => lambda { |x| 
+          :dynamic_version => lambda { |x|
             _first_header_capture(x,/^microsoftsharepointteamservices:(.*)/i) },
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => true
         },
         {
@@ -819,7 +819,7 @@ module Intrigue
           :version => nil,
           :match_type => :content_generator,
           :match_content =>  /^Microsoft SharePoint$/,
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => false
         },
         {
@@ -833,7 +833,7 @@ module Intrigue
           :match_type => :content_headers,
           :match_content =>  /microsoftofficewebserver:.*/,
           :dynamic_version => lambda { |x| _first_header_capture(x,/^microsoftofficewebserver:(.*)/i) },
-          :paths => ["#{url}"], 
+          :paths => ["#{url}"],
           :inference => true
         },
         {
@@ -847,10 +847,10 @@ module Intrigue
           :match_type => :content_headers,
           :match_content =>  /microsoftofficewebserver: 5.0_Pub/,
           :paths => ["#{url}"]
-        }        
+        }
       ]
     end
-  
+
     # https://buildnumbers.wordpress.com/sharepoint/
     # https://www.eukhost.com/blog/webhosting/difference-between-windows-sharepoint-services-and-sharepoint-servers/
     # https://sathiya.io/sharepoint-2016-build-numbers
@@ -858,31 +858,31 @@ module Intrigue
 
       # adjust the version to fit our naming scheme
       # simpluy  remove one of the .0's
-      sp_version = sp_teamsvc_version.gsub("0.0.","0.") 
+      sp_version = sp_teamsvc_version.gsub("0.0.","0.")
 
       reference_versions = File.open("#{$ident_dir}/data/microsoft_sharepoint_versions.csv").read.split("\n")
 
-      # do the comparison and simply return if we ahve it 
+      # do the comparison and simply return if we ahve it
       reference_versions.each do |line|
-        # it's a csv 
+        # it's a csv
         ref = line.split(",")
 
         # grab the relevant fields
         sp_release = ref[0]
         build_version = ref[1]
         update_version = ref[2]
-        
+
         # modify to fit our schema
         compare_version = build_version.gsub(/\.\d+$/,"")
-        if compare_version == sp_version # # Got it 
+        if compare_version == sp_version # # Got it
           # recturn since we matched
           return { version: sp_release, update: update_version }
         end
-      end      
+      end
 
       # okay we made it this far, so no exact match
-      # handle cases where we don't have an exact match here     
-      case 
+      # handle cases where we don't have an exact match here
+      case
       when sp_teamsvc_version =~ /^10\.0\.0\.\d+/
         out = { version: "2003", update: nil }
       when sp_teamsvc_version =~ /^11\.0\.0\.\d+/
@@ -897,23 +897,23 @@ module Intrigue
         out = { version: "2016", update: nil }
       when sp_teamsvc_version =~ /^16\.0\.10\d+\.\d+/
         out = { version: "2019", update: nil }
-      else 
+      else
         out = { version: nil, update: nil }
       end
-  
-      
-    out 
+
+
+    out
     end
-  
-    
+
+
     # https://en.wikipedia.org/wiki/Internet_Information_Services
     def iis_to_os_version(iis_version)
-     
-      case 
+
+      case
       when iis_version == "10.0.17763"
         out = { version: " Windows Server 2019 or Windows 10 October Update" }
       when iis_version == "10.0"
-        out = { version: " Windows Server, version 1709 (Semi-Annual Channel) or Windows 10 Fall Creators Update" }          
+        out = { version: " Windows Server, version 1709 (Semi-Annual Channel) or Windows 10 Fall Creators Update" }
       when iis_version == "10.0.14393" # IIS 10.0 version 1607
         out = { version: "Windows Server 2016 or Windows 10 Anniversary Update" }
       when iis_version == "8.5"
@@ -942,272 +942,272 @@ module Intrigue
 
     out
     end
-  
+
     def owa_to_exchange_version(owa_version)
 
       # 2007 SP1
       if owa_version == "8.1.240.6" #.32"
         out = { version: "2007 SP1", update: "RTM" }
       elsif owa_version == "8.1.263.1" #.32"
-        out = { version: "2007 SP1", update: "Update Rollup 1" }  
+        out = { version: "2007 SP1", update: "Update Rollup 1" }
       elsif owa_version == "8.1.278.2" #.32"
-        out = { version: "2007 SP1", update: "Update Rollup 2" }  
+        out = { version: "2007 SP1", update: "Update Rollup 2" }
       elsif owa_version == "8.1.291.2" #.32"
-        out = { version: "2007 SP1", update: "Update Rollup 3" }  
+        out = { version: "2007 SP1", update: "Update Rollup 3" }
       elsif owa_version == "8.1.311.3" #.32"
-        out = { version: "2007 SP1", update: "Update Rollup 4" }  
+        out = { version: "2007 SP1", update: "Update Rollup 4" }
       elsif owa_version == "8.1.336.1" #.32"
-        out = { version: "2007 SP1", update: "Update Rollup 5" }  
+        out = { version: "2007 SP1", update: "Update Rollup 5" }
       elsif owa_version == "8.1.340.1" #.32"
-        out = { version: "2007 SP1", update: "Update Rollup 6" }  
+        out = { version: "2007 SP1", update: "Update Rollup 6" }
       elsif owa_version == "8.1.359.2" #.32"
-        out = { version: "2007 SP1", update: "Update Rollup 7" }  
+        out = { version: "2007 SP1", update: "Update Rollup 7" }
       elsif owa_version == "8.1.375.2" #.32"
-        out = { version: "2007 SP1", update: "Update Rollup 8" }  
+        out = { version: "2007 SP1", update: "Update Rollup 8" }
       elsif owa_version == "8.1.393.1" #.32"
-        out = { version: "2007 SP1", update: "Update Rollup 9" }  
+        out = { version: "2007 SP1", update: "Update Rollup 9" }
       elsif owa_version == "8.1.436.0" #.32"
-        out = { version: "2007 SP1", update: "Update Rollup 10" }  
-      
-      # 2007 SP2 
+        out = { version: "2007 SP1", update: "Update Rollup 10" }
+
+      # 2007 SP2
       elsif owa_version == "8.2.176.2" #.32"
-        out = { version: "2007 SP2", update: "RTM" }  
+        out = { version: "2007 SP2", update: "RTM" }
       elsif owa_version == "8.2.217.3" #.32"
-        out = { version: "2007 SP2", update: "Update Rollup 1" }  
+        out = { version: "2007 SP2", update: "Update Rollup 1" }
       elsif owa_version == "8.2.234.1" #.32"
-        out = { version: "2007 SP2", update: "Update Rollup 2" }  
+        out = { version: "2007 SP2", update: "Update Rollup 2" }
       elsif owa_version == "8.2.247.2" #.32"
-        out = { version: "2007 SP2", update: "Update Rollup 3" }  
+        out = { version: "2007 SP2", update: "Update Rollup 3" }
       elsif owa_version == "8.2.254.0" #.32"
-        out = { version: "2007 SP2", update: "Update Rollup 4" }  
+        out = { version: "2007 SP2", update: "Update Rollup 4" }
       elsif owa_version == "8.2.305.3" #.32"
-        out = { version: "2007 SP2", update: "Update Rollup 5" }  
-      
-       # 2007 SP3 
+        out = { version: "2007 SP2", update: "Update Rollup 5" }
+
+       # 2007 SP3
       elsif owa_version == "8.3.083.6" #.32"
-        out = { version: "2007 SP3", update: "RTM" }  
+        out = { version: "2007 SP3", update: "RTM" }
       elsif owa_version == "8.3.106.2" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 1" }  
+        out = { version: "2007 SP3", update: "Update Rollup 1" }
       elsif owa_version == "8.3.137.3" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 2" }  
+        out = { version: "2007 SP3", update: "Update Rollup 2" }
       elsif owa_version == "8.3.159.0" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 3" }  
+        out = { version: "2007 SP3", update: "Update Rollup 3" }
       elsif owa_version == "8.3.159.2" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 3-v2" }  
+        out = { version: "2007 SP3", update: "Update Rollup 3-v2" }
       elsif owa_version == "8.3.192.1" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 4" }          
+        out = { version: "2007 SP3", update: "Update Rollup 4" }
       elsif owa_version == "8.3.213.1" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 5" }  
+        out = { version: "2007 SP3", update: "Update Rollup 5" }
       elsif owa_version == "8.3.245.2" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 6" }  
+        out = { version: "2007 SP3", update: "Update Rollup 6" }
       elsif owa_version == "8.3.264.0" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 7" }  
+        out = { version: "2007 SP3", update: "Update Rollup 7" }
       elsif owa_version == "8.3.279.3" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 8" }  
+        out = { version: "2007 SP3", update: "Update Rollup 8" }
       elsif owa_version == "8.3.279.5" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 8-v2" }  
+        out = { version: "2007 SP3", update: "Update Rollup 8-v2" }
       elsif owa_version == "8.3.279.6" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 8-v3" }  
+        out = { version: "2007 SP3", update: "Update Rollup 8-v3" }
       elsif owa_version == "8.3.297.2" #.32
-        out = { version: "2007 SP3", update: "Update Rollup 9" }  
+        out = { version: "2007 SP3", update: "Update Rollup 9" }
       elsif owa_version == "8.3.298.3" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 10" }  
+        out = { version: "2007 SP3", update: "Update Rollup 10" }
       elsif owa_version == "8.3.327.1" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 11" }  
+        out = { version: "2007 SP3", update: "Update Rollup 11" }
       elsif owa_version == "8.3.342.4" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 12" }  
+        out = { version: "2007 SP3", update: "Update Rollup 12" }
       elsif owa_version == "8.3.348.1" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 13" }  
+        out = { version: "2007 SP3", update: "Update Rollup 13" }
       elsif owa_version == "8.3.379.2" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 14" }  
+        out = { version: "2007 SP3", update: "Update Rollup 14" }
       elsif owa_version == "8.3.389.2" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 15" }  
+        out = { version: "2007 SP3", update: "Update Rollup 15" }
       elsif owa_version == "8.3.406.0" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 16" }  
+        out = { version: "2007 SP3", update: "Update Rollup 16" }
       elsif owa_version == "8.3.417.1" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 17" }  
+        out = { version: "2007 SP3", update: "Update Rollup 17" }
       elsif owa_version == "8.3.445.0" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 18" }  
+        out = { version: "2007 SP3", update: "Update Rollup 18" }
       elsif owa_version == "8.3.459.0" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 19" }  
+        out = { version: "2007 SP3", update: "Update Rollup 19" }
       elsif owa_version == "8.3.468.0" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 20" }  
+        out = { version: "2007 SP3", update: "Update Rollup 20" }
       elsif owa_version == "8.4.485.1" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 21" }  
+        out = { version: "2007 SP3", update: "Update Rollup 21" }
       elsif owa_version == "8.3.502.0" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 22" }  
+        out = { version: "2007 SP3", update: "Update Rollup 22" }
       elsif owa_version == "8.3.517.0" #.32"
-        out = { version: "2007 SP3", update: "Update Rollup 23" }  
+        out = { version: "2007 SP3", update: "Update Rollup 23" }
 
       # 2010
       elsif owa_version == "14.0.639.21"
-        out = { version: "2010", update: "RTM" }  
+        out = { version: "2010", update: "RTM" }
       elsif owa_version == "14.0.682.1"
-        out = { version: "2010", update: "Update Rollup 1" }  
+        out = { version: "2010", update: "Update Rollup 1" }
       elsif owa_version == "14.0.689.0"
-        out = { version: "2010", update: "Update Rollup 2" }  
+        out = { version: "2010", update: "Update Rollup 2" }
       elsif owa_version == "14.0.694.0"
-        out = { version: "2010", update: "Update Rollup 3" }          
+        out = { version: "2010", update: "Update Rollup 3" }
       elsif owa_version == "14.0.702.1"
-        out = { version: "2010", update: "Update Rollup 4" }  
+        out = { version: "2010", update: "Update Rollup 4" }
       elsif owa_version == "14.0.722.0" # unknown release, found in the wild
-        out = { version: "2010", update: "Update Rollup 4", 
-          note: "additional updates applied: #{owa_version}" }  
+        out = { version: "2010", update: "Update Rollup 4",
+          note: "additional updates applied: #{owa_version}" }
       elsif owa_version == "14.0.726.0"
-        out = { version: "2010", update: "Update Rollup 5" }  
-      
+        out = { version: "2010", update: "Update Rollup 5" }
+
       # 2010 SP1
       elsif owa_version == "14.1.218.13" || owa_version == "14.1.218.15"
-        out = { version: "2010 SP1", update: "RTM" }  
+        out = { version: "2010 SP1", update: "RTM" }
       elsif owa_version == "14.1.255.2"
-        out = { version: "2010 SP1", update: "Update Rollup 1" }  
+        out = { version: "2010 SP1", update: "Update Rollup 1" }
       elsif owa_version == "14.1.270.1"
-        out = { version: "2010 SP1", update: "Update Rollup 2" }  
+        out = { version: "2010 SP1", update: "Update Rollup 2" }
       elsif owa_version == "14.1.287.0"
-        out = { version: "2010 SP1", update: "Update Rollup 2", 
-          note: "additional updates applied: #{owa_version}" }  
+        out = { version: "2010 SP1", update: "Update Rollup 2",
+          note: "additional updates applied: #{owa_version}" }
       elsif owa_version == "14.1.289.3"
-        out = { version: "2010 SP1", update: "Update Rollup 3" }  
+        out = { version: "2010 SP1", update: "Update Rollup 3" }
       elsif owa_version == "14.1.289.7"
-        out = { version: "2010 SP1", update: "Update Rollup 3-v3" }  
+        out = { version: "2010 SP1", update: "Update Rollup 3-v3" }
       elsif owa_version == "14.1.323.1"
-        out = { version: "2010 SP1", update: "Update Rollup 4" }  
+        out = { version: "2010 SP1", update: "Update Rollup 4" }
       elsif owa_version == "14.1.323.6"
-        out = { version: "2010 SP1", update: "Update Rollup 4-v2" }  
+        out = { version: "2010 SP1", update: "Update Rollup 4-v2" }
       elsif owa_version == "14.1.339.1"
-        out = { version: "2010 SP1", update: "Update Rollup 5" }  
+        out = { version: "2010 SP1", update: "Update Rollup 5" }
       elsif owa_version == "14.1.355.2"
-        out = { version: "2010 SP1", update: "Update Rollup 6" }  
+        out = { version: "2010 SP1", update: "Update Rollup 6" }
       elsif owa_version == "14.1.420.0"
-        out = { version: "2010 SP1", update: "Update Rollup 6", 
-          note: "additional updates applied: #{owa_version}"  }  
+        out = { version: "2010 SP1", update: "Update Rollup 6",
+          note: "additional updates applied: #{owa_version}"  }
       elsif owa_version == "14.1.421.0"
-        out = { version: "2010 SP1", update: "Update Rollup 7" }  
+        out = { version: "2010 SP1", update: "Update Rollup 7" }
       elsif owa_version == "14.1.421.2"
-        out = { version: "2010 SP1", update: "Update Rollup 7-v2" }  
+        out = { version: "2010 SP1", update: "Update Rollup 7-v2" }
       elsif owa_version == "14.1.421.3"
-        out = { version: "2010 SP1", update: "Update Rollup 7-v3" }  
+        out = { version: "2010 SP1", update: "Update Rollup 7-v3" }
       elsif owa_version == "14.1.438.0"
-        out = { version: "2010 SP1", update: "Update Rollup 8" }  
+        out = { version: "2010 SP1", update: "Update Rollup 8" }
 
-      # 2010 SP2 
+      # 2010 SP2
       elsif owa_version == "14.2.247.5"
-        out = { version: "2010 SP2", update: "RTM" }  
+        out = { version: "2010 SP2", update: "RTM" }
       elsif owa_version == "14.2.283.3"
-        out = { version: "2010 SP2", update: "Update Rollup 1" }  
+        out = { version: "2010 SP2", update: "Update Rollup 1" }
       elsif owa_version == "14.2.298.4"
-        out = { version: "2010 SP2", update: "Update Rollup 2" }  
+        out = { version: "2010 SP2", update: "Update Rollup 2" }
       elsif owa_version == "14.2.309.2"
-        out = { version: "2010 SP2", update: "Update Rollup 3" }  
+        out = { version: "2010 SP2", update: "Update Rollup 3" }
       elsif owa_version == "14.2.318.2"
-        out = { version: "2010 SP2", update: "Update Rollup 4" }  
+        out = { version: "2010 SP2", update: "Update Rollup 4" }
       elsif owa_version == "14.2.318.4"
-        out = { version: "2010 SP2", update: "Update Rollup 4-v2" }  
+        out = { version: "2010 SP2", update: "Update Rollup 4-v2" }
       elsif owa_version == "14.2.328.5"
-        out = { version: "2010 SP2", update: "Update Rollup 5" }  
+        out = { version: "2010 SP2", update: "Update Rollup 5" }
       elsif owa_version == "14.2.328.9" || owa_version == "14.2.328.10"
-        out = { version: "2010 SP2", update: "Update Rollup 5-v2" }  
+        out = { version: "2010 SP2", update: "Update Rollup 5-v2" }
       elsif owa_version == "14.2.342.3"
-        out = { version: "2010 SP2", update: "Update Rollup 6" }  
+        out = { version: "2010 SP2", update: "Update Rollup 6" }
       elsif owa_version == "14.2.347.0"
         out = { version: "2010 SP2", update: "Update Rollup 6",
-          note: "additional updates applied: #{owa_version}" }  
+          note: "additional updates applied: #{owa_version}" }
       elsif owa_version == "14.2.375.0"
-        out = { version: "2010 SP2", update: "Update Rollup 7" }  
+        out = { version: "2010 SP2", update: "Update Rollup 7" }
       elsif owa_version == "14.2.390.1" # unknown release, found in the wild
-        out = { version: "2010 SP2", update: "Update Rollup 8", 
-          note: "prerelease version: #{owa_version}"  }  
+        out = { version: "2010 SP2", update: "Update Rollup 8",
+          note: "prerelease version: #{owa_version}"  }
       elsif owa_version == "14.2.390.3"
-        out = { version: "2010 SP2", update: "Update Rollup 8" }  
+        out = { version: "2010 SP2", update: "Update Rollup 8" }
 
       # 2010 SP3
       elsif owa_version == "14.3.123.3" || owa_version == "14.3.123.3"
-        out = { version: "2010 SP3", update: "RTM" }  
+        out = { version: "2010 SP3", update: "RTM" }
       elsif owa_version == "14.3.146.0"
-        out = { version: "2010 SP3", update: "Update Rollup 1" }  
+        out = { version: "2010 SP3", update: "Update Rollup 1" }
       elsif owa_version == "14.3.158.1"
-        out = { version: "2010 SP3", update: "Update Rollup 2" }  
+        out = { version: "2010 SP3", update: "Update Rollup 2" }
       elsif owa_version == "14.3.169.1"
-        out = { version: "2010 SP3", update: "Update Rollup 3" }  
+        out = { version: "2010 SP3", update: "Update Rollup 3" }
       elsif owa_version == "14.3.174.1"
-        out = { version: "2010 SP3", update: "Update Rollup 4" }  
+        out = { version: "2010 SP3", update: "Update Rollup 4" }
       elsif owa_version == "14.3.181.6"
-        out = { version: "2010 SP3", update: "Update Rollup 5" }  
+        out = { version: "2010 SP3", update: "Update Rollup 5" }
       elsif owa_version == "14.3.195.1"
-        out = { version: "2010 SP3", update: "Update Rollup 6" }  
+        out = { version: "2010 SP3", update: "Update Rollup 6" }
       elsif owa_version == "14.3.210.2"
-        out = { version: "2010 SP3", update: "Update Rollup 7" }  
+        out = { version: "2010 SP3", update: "Update Rollup 7" }
       elsif owa_version == "14.3.224.2"
-        out = { version: "2010 SP3", update: "Update Rollup 8-v2" }  
+        out = { version: "2010 SP3", update: "Update Rollup 8-v2" }
       elsif owa_version == "14.3.235.1"
-        out = { version: "2010 SP3", update: "Update Rollup 9" }  
+        out = { version: "2010 SP3", update: "Update Rollup 9" }
       elsif owa_version == "14.3.248.2"
-        out = { version: "2010 SP3", update: "Update Rollup 10" }  
+        out = { version: "2010 SP3", update: "Update Rollup 10" }
       elsif owa_version == "14.3.266.1"
-        out = { version: "2010 SP3", update: "Update Rollup 11" }  
+        out = { version: "2010 SP3", update: "Update Rollup 11" }
       elsif owa_version == "14.3.279.2"
-        out = { version: "2010 SP3", update: "Update Rollup 12" }  
+        out = { version: "2010 SP3", update: "Update Rollup 12" }
       elsif owa_version == "14.3.294.0"
-        out = { version: "2010 SP3", update: "Update Rollup 13" }  
+        out = { version: "2010 SP3", update: "Update Rollup 13" }
       elsif owa_version == "14.3.301.0"
-        out = { version: "2010 SP3", update: "Update Rollup 14" }  
+        out = { version: "2010 SP3", update: "Update Rollup 14" }
       elsif owa_version == "14.3.319.2"
-        out = { version: "2010 SP3", update: "Update Rollup 15" }  
+        out = { version: "2010 SP3", update: "Update Rollup 15" }
       elsif owa_version == "14.3.339.0"
-        out = { version: "2010 SP3", update: "Update Rollup 16" }  
+        out = { version: "2010 SP3", update: "Update Rollup 16" }
       elsif owa_version == "14.3.351.0"
-        out = { version: "2010 SP3", update: "Update Rollup 16", 
-          note: "additional updates applied: #{owa_version}" }  
+        out = { version: "2010 SP3", update: "Update Rollup 16",
+          note: "additional updates applied: #{owa_version}" }
       elsif owa_version == "14.3.352.0"
-        out = { version: "2010 SP3", update: "Update Rollup 17" }  
+        out = { version: "2010 SP3", update: "Update Rollup 17" }
       elsif owa_version == "14.3.361.1"
-        out = { version: "2010 SP3", update: "Update Rollup 18" }  
+        out = { version: "2010 SP3", update: "Update Rollup 18" }
       elsif owa_version == "14.3.382.0"
-        out = { version: "2010 SP3", update: "Update Rollup 19" }  
+        out = { version: "2010 SP3", update: "Update Rollup 19" }
       elsif owa_version == "14.3.388.0" # found in the wild
-        out = { version: "2010 SP3", update: "Update Rollup 19", 
-          note: "additional updates applied: #{owa_version}"  }  
+        out = { version: "2010 SP3", update: "Update Rollup 19",
+          note: "additional updates applied: #{owa_version}"  }
       elsif owa_version == "14.3.389.1"
-        out = { version: "2010 SP3", update: "Update Rollup 20" }  
-      elsif owa_version == "14.3.399.0" 
-        out = { version: "2010 SP3", update: "Update Rollup 21", 
-          note: "additional updates applied: #{owa_version}"  }  
+        out = { version: "2010 SP3", update: "Update Rollup 20" }
+      elsif owa_version == "14.3.399.0"
+        out = { version: "2010 SP3", update: "Update Rollup 21",
+          note: "additional updates applied: #{owa_version}"  }
       elsif owa_version == "14.3.399.2"
-        out = { version: "2010 SP3", update: "Update Rollup 21" }  
+        out = { version: "2010 SP3", update: "Update Rollup 21" }
       elsif owa_version == "14.3.409.0"
-        out = { version: "2010 SP3", update: "Update Rollup 21", 
-          note: "additional updates applied: #{owa_version}"  }  
+        out = { version: "2010 SP3", update: "Update Rollup 21",
+          note: "additional updates applied: #{owa_version}"  }
       elsif owa_version == "14.3.411.0"
-        out = { version: "2010 SP3", update: "Update Rollup 22" }  
+        out = { version: "2010 SP3", update: "Update Rollup 22" }
       elsif owa_version == "14.3.415.0"
-        out = { version: "2010 SP3", update: "Update Rollup 22", 
+        out = { version: "2010 SP3", update: "Update Rollup 22",
           note: "additional updates applied: #{owa_version}"  }
       elsif owa_version == "14.3.417.0"
-        out = { version: "2010 SP3", update: "Update Rollup 23" }  
+        out = { version: "2010 SP3", update: "Update Rollup 23" }
       elsif owa_version == "14.3.419.0"
-        out = { version: "2010 SP3", update: "Update Rollup 24" }  
+        out = { version: "2010 SP3", update: "Update Rollup 24" }
       elsif owa_version == "14.3.435.0"
-        out = { version: "2010 SP3", update: "Update Rollup 25" }  
+        out = { version: "2010 SP3", update: "Update Rollup 25" }
       elsif owa_version == "14.3.439.0" # unknown release, found in the wild
-        out = { version: "2010 SP3", update: "Update Rollup 25", 
-          note: "additional updates applied: #{owa_version}" }  
+        out = { version: "2010 SP3", update: "Update Rollup 25",
+          note: "additional updates applied: #{owa_version}" }
       elsif owa_version == "14.3.442.0"
-        out = { version: "2010 SP3", update: "Update Rollup 26" }  
+        out = { version: "2010 SP3", update: "Update Rollup 26" }
       elsif owa_version == "14.3.452.0"
-        out = { version: "2010 SP3", update: "Update Rollup 27" }  
+        out = { version: "2010 SP3", update: "Update Rollup 27" }
       elsif owa_version == "14.3.461.1"
-        out = { version: "2010 SP3", update: "Update Rollup 28" }  
+        out = { version: "2010 SP3", update: "Update Rollup 28" }
       elsif owa_version == "14.3.468.0"
-        out = { version: "2010 SP3", update: "Update Rollup 29" }  
+        out = { version: "2010 SP3", update: "Update Rollup 29" }
       elsif owa_version == "14.3.487.0" # unknown release, found in the wild
         out = { version: "2010 SP3", update: "Update Rollup 29",
-           note: "additional updates applied: #{owa_version}" }  
+           note: "additional updates applied: #{owa_version}" }
       elsif owa_version == "14.3.496.0"
-        out = { version: "2010 SP3", update: "Update Rollup 30" }      
-        
+        out = { version: "2010 SP3", update: "Update Rollup 30" }
+
       # 2013
       elsif owa_version == "15.0.516" #.32"
-          out = { version: "2013", update: "RTM" }  
+          out = { version: "2013", update: "RTM" }
       elsif owa_version == "15.0.620" #.29"
         out = { version: "2013", update: "Cumulative Update 1" }
       elsif owa_version == "15.0.712" #.24"
@@ -1250,13 +1250,13 @@ module Intrigue
         out = { version: "2013", update: "Cumulative Update 20" }
       elsif owa_version == "15.0.1395" #.4"
         out = { version: "2013", update: "Cumulative Update 21" }
-      elsif owa_version == "15.0.1473.3" || owa_version == "15.0.1473"  
+      elsif owa_version == "15.0.1473.3" || owa_version == "15.0.1473"
         out = { version: "2013", update: "Cumulative Update 22" }
-      elsif owa_version == "15.0.1497" 
+      elsif owa_version == "15.0.1497"
         out = { version: "2013", update: "Cumulative Update 23" }
-      elsif owa_version == "15.0.1497.2" 
+      elsif owa_version == "15.0.1497.2"
         out = { version: "2013", update: "Cumulative Update 23" }
-        
+
       # 2016
       elsif owa_version == "15.1.225" #.16"
         out = { version: "2016", update: "Preview" }
@@ -1295,44 +1295,55 @@ module Intrigue
       elsif owa_version == "15.1.1986" #.01"
         out = { version: "2016", update: "Cumulative Update 15",
           note: "additional updates applied: #{owa_version}" }
+      elsif owa_version == "15.1.1979" #.01"
+        out = { version: "2016", update: "Cumulative Update 16" }
+      elsif owa_version == "15.1.2044" #.01"
+        out = { version: "2016", update: "Cumulative Update 17" }
 
 
       # 2019
+      # taken from https://docs.microsoft.com/en-us/Exchange/new-features/build-numbers-and-release-dates?redirectedfrom=MSDN&view=exchserver-2019
       elsif owa_version == "15.2.196.0" #
         out = { version: "2019", update: "Preview" }
       elsif owa_version == "15.2.221" || owa_version == "15.2.221.12" #
         out = { version: "2019", update: "RTM" }
-      elsif owa_version == "15.2.330" || owa_version == "15.2.330.6" #
+      elsif owa_version == "15.2.330" || owa_version == "15.2.330.5" #
         out = { version: "2019", update: "Cumulative Update 1" }
       elsif owa_version == "15.2.397" || owa_version == "15.2.397.3" #
         out = { version: "2019", update: "Cumulative Update 2" }
-      elsif owa_version == "15.2.464" ||  owa_version == "15.2.529" #
-        out = { version: "2019", update: "Cumulative Update 3", 
-          note: "additional updates applied: #{owa_version}" }
-        
-=begin 
-1694  Microsoft Exchange Server [Unknown 15.2.221] [Unknown 15.2.221], Exchange Server 2019 RTM	
-2287  Microsoft Exchange Server [Unknown 15.2.397] [Unknown 15.2.397], Exchange Server 2019 CU2	
-2464  Microsoft Exchange Server [Unknown 15.2.330] [Unknown 15.2.330], Exchange Server 2019 CU1	
-2670  Microsoft Exchange Server [Unknown 15.1.544] [Unknown 15.1.544], Exchange Server 2016 CU3	
-3609  Microsoft Exchange Server [Unknown 15.2.464] [Unknown 15.2.464], Exchange Server 2019 CU3	
-14034  Microsoft Exchange Server [Unknown 15.1.1713] [Unknown 15.1.1713], Exchange Server 2016 CU12	
+      elsif owa_version == "15.2.464" ||  owa_version == "15.2.464.5" #
+        out = { version: "2019", update: "Cumulative Update 3"}
+      elsif owa_version == "15.2.529" ||  owa_version == "15.2.529.5" #
+        out = { version: "2019", update: "Cumulative Update 4"}
+      elsif owa_version == "15.2.595" ||  owa_version == "15.2.595.3" #
+        out = { version: "2019", update: "Cumulative Update 5"}
+      elsif owa_version == "15.2.659" ||  owa_version == "15.2.659.4" #
+        out = { version: "2019", update: "Cumulative Update 6"}
 
-=end 
-          
+          #note: "additional updates applied: #{owa_version}" }
+
+=begin
+1694  Microsoft Exchange Server [Unknown 15.2.221] [Unknown 15.2.221], Exchange Server 2019 RTM
+2287  Microsoft Exchange Server [Unknown 15.2.397] [Unknown 15.2.397], Exchange Server 2019 CU2
+2464  Microsoft Exchange Server [Unknown 15.2.330] [Unknown 15.2.330], Exchange Server 2019 CU1
+2670  Microsoft Exchange Server [Unknown 15.1.544] [Unknown 15.1.544], Exchange Server 2016 CU3
+3609  Microsoft Exchange Server [Unknown 15.2.464] [Unknown 15.2.464], Exchange Server 2019 CU3
+14034  Microsoft Exchange Server [Unknown 15.1.1713] [Unknown 15.1.1713], Exchange Server 2016 CU12
+
+=end
+
       else
         out = { version: "[Unknown #{owa_version}]", update: "[Unknown #{owa_version}]" }
       end
 
-      
-      
+
+
     end
-  
-  
-  
-    
+
+
+
+
   end
   end
   end
   end
-  


### PR DESCRIPTION
Tested against Microsoft Exchange 2019 and works:
```
bundle exec ruby ./util/ident.rb -v -u https://redacted/
Fingerprint: 
 - Microsoft ASP.NET 4.0.30319  - X-AspNet Header (CPE: cpe:2.3:a:microsoft:asp.net:4.0.30319:) (Tags: ["Web Framework"]) (Hide: false) (Issues: ) (Tasks: )
 - Microsoft Exchange Server 2019 Cumulative Update 6 - OWA version -> Exchange server inference (body) (CPE: cpe:2.3:a:microsoft:exchange_server:2019:cumulative_update_6) (Tags: ["Productivity", "COTS", "Mail Server", "Email"]) (Hide: false) (Issues: ) (Tasks: )
   - Vuln: CVE-2019-0586 (CVSS: 10.0) https://nvd.nist.gov/vuln/detail/CVE-2019-0586
   - Vuln: CVE-2019-0724 (CVSS: 9.3) https://nvd.nist.gov/vuln/detail/CVE-2019-0724
   - Vuln: CVE-2020-0688 (CVSS: 9.0) https://nvd.nist.gov/vuln/detail/CVE-2020-0688
   - Vuln: CVE-2019-1233 (CVSS: 7.8) https://nvd.nist.gov/vuln/detail/CVE-2019-1233
   - Vuln: CVE-2019-1373 (CVSS: 7.5) https://nvd.nist.gov/vuln/detail/CVE-2019-1373
 - Microsoft Outlook Web Access 15.2.659  - Microsoft Outlook Web Access (body) (CPE: cpe:2.3:a:microsoft:outlook_web_access:15.2.659:) (Tags: ["Productivity", "Mail Server", "COTS"]) (Hide: false) (Issues: ) (Tasks: )

```

I did not find an exchange 2016 server to test, but I am highly confident this is going to work.