### PR TITLE
Check and version extraction for docker

### DIFF
--- a/checks/http/docker.rb
+++ b/checks/http/docker.rb
@@ -1,0 +1,45 @@
+module Intrigue
+    module Ident
+    module Check
+    class Docker < Intrigue::Ident::Check::Base
+    
+      def generate_checks(url)
+        [
+          {
+            :type => "fingerprint",
+            :category => "application",
+            :tags => ["Virtualization"],
+            :vendor => "Docker",
+            :product =>"Docker",
+            :match_details =>"body content",
+            :match_type => :content_body,
+            :version => nil,
+            :match_content =>  /\"ApiVersion\".*\"KernelVersion\"/,
+            :paths => [ { :path  => "#{url}", :follow_redirects => true } ],
+            :inference => false,
+            :dynamic_version => lambda{ |x|
+          _first_body_capture(x,/\"Version\"\: ?\"(\d+\.\d+\.[a-zA-z0-9\-]{2,})\"/)},
+          },
+          {
+            :type => "fingerprint",
+            :category => "application",
+            :tags => ["Virtualization"],
+            :vendor => "Docker",
+            :product =>"Docker",
+            :match_details =>"header match",
+            :match_type => :content_headers,
+            :version => nil,
+            :match_content =>  /Server\: Docker\/.*/,
+            :paths => [ { :path  => "#{url}", :follow_redirects => true } ],
+            :inference => true,
+            :dynamic_version => lambda{ |x|
+          _first_header_capture(x,/Docker\/(\d+\.\d+\.[a-zA-z0-9\-]{2,})/)},
+          }
+        ]
+      end
+    
+    end
+    end
+    end
+    end
+    


### PR DESCRIPTION
Check and version extraction for docker, tested on multiple targets:
```
shpend@ubuntu:$ bundle exec ./util/ident.rb -u http://[redacted]:2375/version
Fingerprint: 
 - Docker Docker 18.06.1-ce  - body content (CPE: cpe:2.3:a:docker:docker:18.06.1-ce:) (Tags: ["Virtualization"]) (Hide: false) (Issues: ) (Tasks: )
 - Docker Docker 18.06.1-ce  - header match (CPE: cpe:2.3:a:docker:docker:18.06.1-ce:) (Tags: ["Virtualization"]) (Hide: false) (Issues: ) (Tasks: )
shpend@ubuntu:$ bundle exec ./util/ident.rb -u http://[redacted]:2375/version
Fingerprint: 
 - Docker Docker 17.06.2-ee-5  - body content (CPE: cpe:2.3:a:docker:docker:17.06.2-ee-5:) (Tags: ["Virtualization"]) (Hide: false) (Issues: ) (Tasks: )
 - Docker Docker 17.06.2-ee-5  - header match (CPE: cpe:2.3:a:docker:docker:17.06.2-ee-5:) (Tags: ["Virtualization"]) (Hide: false) (Issues: ) (Tasks: )
shpend@ubuntu:$ bundle exec ./util/ident.rb -u http://[redacted]:2375/version
Fingerprint: 
 - Docker Docker 17.05.0-ce  - body content (CPE: cpe:2.3:a:docker:docker:17.05.0-ce:) (Tags: ["Virtualization"]) (Hide: false) (Issues: ) (Tasks: )
 - Docker Docker 17.05.0-ce  - header match (CPE: cpe:2.3:a:docker:docker:17.05.0-ce:) (Tags: ["Virtualization"]) (Hide: false) (Issues: ) (Tasks: )
shpend@ubuntu:$ 

```

Unfortunately there are zero indicators for docker on the root url, making it hard to detect without appending `/version`. A good approach would be to test `/version` whenever we see port 2375/2376, but I dunno how to do that.