### PR TITLE
Fix version comparison issue

### DIFF
--- a/checks/http/webmin.rb
+++ b/checks/http/webmin.rb
@@ -14,10 +14,10 @@ class Webmin < Intrigue::Ident::Check::Base
         :match_details => "miniserv server",
         :match_type => :content_headers,
         :references => [],
-        :match_content => /server: MiniServ/,
+        :match_content => /server: MiniServ/i,
         :version => nil,
         :dynamic_version => lambda { |x| 
-          _first_header_capture(x,/server: MiniServ\/(.*)/)},
+          _first_header_capture(x,/server: MiniServ\/(.*)/i)},
         :paths => [ { :path  => "#{url}", :follow_redirects => true } ],
         :inference => true
       },

--- a/lib/ident.rb
+++ b/lib/ident.rb
@@ -187,6 +187,9 @@ module Intrigue
     private
 
     def _sanitize_string(string)
+      # return nil if string is empty, to allow valid version comparison.
+      return nil if string == "" || string == nil
+
       "#{string}".encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
     end
     
@@ -194,8 +197,8 @@ module Intrigue
 
       if check[:type] == "fingerprint"
 
-        calculated_version = (check[:dynamic_version].call(data) if check[:dynamic_version]) || check[:version] || nil
-        calculated_update = (check[:dynamic_update].call(data) if check[:dynamic_update]) || check[:update] || nil
+        calculated_version = (check[:dynamic_version].call(data) if check[:dynamic_version]) || check[:version]
+        calculated_update = (check[:dynamic_update].call(data) if check[:dynamic_update]) || check[:update]
 
         calculated_type = "a" if check[:category] == "application"
         calculated_type = "h" if check[:category] == "hardware"
@@ -252,8 +255,8 @@ module Intrigue
           "type" => check[:type],
           "vendor" => check[:vendor],
           "product" => check[:product],
-          "version" => "#{_sanitize_string(calculated_version)}",
-          "update" => "#{_sanitize_string(calculated_update)}",
+          "version" => _sanitize_string(calculated_version),
+          "update" => _sanitize_string(calculated_update),
           "tags" => check[:tags],
           "match_type" => check[:match_type],
           "match_details" => check[:match_details],


### PR DESCRIPTION
This commit fixes the version comparison issue, where a version would be returend as an empty string and when compared against the vulnerable version, it would be concluded as smaller.

The commit also fixes the regex for webmin, which was incorrect.