### PR TITLE
Moodle version detection via /lib/upgrade.txt

### DIFF
--- a/checks/http/moodle.rb
+++ b/checks/http/moodle.rb
@@ -17,6 +17,24 @@ module Intrigue
             :match_content =>  /MoodleSession=/i,
             :paths => [ { :path  => "#{url}", :follow_redirects => true } ],
             :inference => false
+          },
+          {
+            :type => "fingerprint",
+            :category => "application",
+            :tags => ["CMS"],
+            :vendor =>"Moodle",
+            :product =>"Moodle",
+            :match_details =>"Version detection via /lib/upgrade.txt",
+            :version => nil,
+            :match_type => :content_body,
+            :match_content =>  /This files describes API changes in core libraries and APIs/i,
+            :paths => [ { :path  => "#{url}/lib/upgrade.txt", :follow_redirects => true } ],
+            :inference => true,
+            :require_product => "Moodle",
+            :dynamic_version => lambda {
+              |x|
+              _first_body_capture(x, /\=\=\= (\d+(\.\d+)*) \=\=\=/i)
+            },
           }
         ]
       end


### PR DESCRIPTION
This PR improves the Moodle fingerprint, to detect the version through /lib/upgrade.txt. After extensive testing, this seems to be a reliable source for finding the moodle version.