### PR TITLE
add uri_host functionality

### DIFF
--- a/checks/http/base.rb
+++ b/checks/http/base.rb
@@ -9,8 +9,12 @@ class Base
     Intrigue::Ident::Http::CheckFactory.register(base)
   end
 
-  def product_name
-
+  def uri_host(url)
+    begin 
+      URI.parse(url).host
+    rescue URI::InvalidURIError => e
+      puts "WARNING! attempted to parse invalid URL! #{url}"
+    end
   end
 
   private


### PR DESCRIPTION
 essentially just wrapping Uri.parse so… we dont have errors when invalid (non parseable) uri is passed. 

This is the go-forward way to pull the base host when adjusing the path for checks.