### PR TITLE
Duplicate HTTP Header Fix

### DIFF
--- a/lib/http/http.rb
+++ b/lib/http/http.rb
@@ -291,7 +291,7 @@ module Http
 
     # verify we have a response before adding these
     if response
-          out[:response_headers] = response.headers.map { |x, y| y.kind_of?(Array) ? y.map { |v| ident_encode("#{x}: #{v}") } : ident_encode("#{x}: #{y}") }
+      out[:response_headers] = response.headers.map { |x, y| y.kind_of?(Array) ? y.map { |v| ident_encode("#{x}: #{v}") } : ident_encode("#{x}: #{y}") }
       out[:response_body_binary_base64] = Base64.strict_encode64(response.body)
       out[:response_body] = ident_encode(response.body)
       out[:response_code] = response.code

--- a/lib/http/http.rb
+++ b/lib/http/http.rb
@@ -291,7 +291,7 @@ module Http
 
     # verify we have a response before adding these
     if response
-      out[:response_headers] = response.headers.map{|x,y| ident_encode "#{x}: #{y}" }
+          out[:response_headers] = response.headers.map { |x, y| y.kind_of?(Array) ? y.map { |v| ident_encode("#{x}: #{v}") } : ident_encode("#{x}: #{y}") }
       out[:response_body_binary_base64] = Base64.strict_encode64(response.body)
       out[:response_body] = ident_encode(response.body)
       out[:response_code] = response.code
@@ -301,7 +301,6 @@ module Http
 
   out
   end
-
 end
 end
 end


### PR DESCRIPTION
Hi team,

Very rarely does a response have duplicate headers, however it is possible as stated in [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2). The issue here is that when Typhoeus comes across a response with duplicate headers, it saves it as a hash with the key being the header name and the value being an array of the header values, an example being:

```
"headers"=>["Server: [\"Apache\", \"Apache\"]"
```

After Ident stores the response headers in the `out` hash, it will look as the following:

```
Server: [\"Apache\", \"Apache\"]
```

The problem now becomes when Ident compares the response header to the list of fingerprints, it's comparing the literal array meaning the result will always return false.

As such I've added an additional bit of logic to the block which is responsible for storing the response headers returned from Typhoeus. The added logic will perform a ternary operation to check if the value of the header returned from Typhoeus is an array, and if so it will call `ident_encode` on each iteration in order to create individual response headers for each item.

Response Headers:

```
HTTP/1.0 200 OK
Server: Apache
Server: Apache
Content-Type: text/html; charset=utf-8
Content-Length: 5
Date: Sat, 19 Dec 2020 03:26:44 GMT
```

Before:
```
maxim@bugbox:~/Desktop/intrigue/intrigue-ident|main ⇒  bundle exec util/ident.rb --uri "http://localhost:8008/doubleheader"
Fingerprint:
```

After:
```
maxim@bugbox:~/Desktop/intrigue/intrigue-ident|doubleheader-fix ⇒  bundle exec util/ident.rb --uri "http://localhost:8008/doubleheader"
Fingerprint:
 - Apache HTTP Server   - Apache server header w/o version (CPE: cpe:2.3:a:apache:http_server::) (Tags: ["WebServer"]) (Hide: false) (Issues: ) (Tasks: )
 - Apache HTTP Server   - Apache web server - server header - no version (CPE: cpe:2.3:a:apache:http_server::) (Tags: ["WebServer"]) (Hide: false) (Issues: ) (Tasks: )
 ```

I've tested this further and it doesn't appear to break any existing functionalities. However as this happens so rarely I'm unsure how needed this.

Anyways thanks for reading,
Maxim

