### PR TITLE
support the "require_vendor" keyword for fingerprints

### DIFF
--- a/lib/http/check_factory.rb
+++ b/lib/http/check_factory.rb
@@ -23,9 +23,17 @@ class CheckFactory
     #
     def self.generate_initial_checks(url)
       @checks.map{ |x| x.new.generate_checks("#{url}") }.flatten.compact.select{|x| 
-        x[:require_product] == nil && x[:require_vendor_product] == nil }
+        x[:require_product] == nil && x[:require_vendor] == nil && x[:require_vendor_product] == nil }
     end
 
+    #
+    # Provide checks given a vendor
+    #
+    def self.generate_checks_for_vendor(url,vendor)
+      @checks.map{ |x| x.new.generate_checks("#{url}") }.flatten.compact.select{|x| 
+        x[:require_vendor] == "#{vendor}" }
+    end
+    
     #
     # Provide checks givene a product
     #

--- a/lib/http/http.rb
+++ b/lib/http/http.rb
@@ -80,6 +80,12 @@ module Http
     detected_products.each do |prod|
       followon_checks.concat(Intrigue::Ident::Http::CheckFactory.generate_checks_for_product("#{url}", prod))
     end
+
+    ### Add checks for vendors
+    detected_products = initial_results["fingerprint"].map{|x| x["vendor"] }.uniq
+    detected_products.each do |vendor|
+      followon_checks.concat(Intrigue::Ident::Http::CheckFactory.generate_checks_for_vendor("#{url}", vendor))
+    end
    
     ### Okay so, now we have a set of detected products, let's figure out our follown checks by vendor_product
     detected_vendor_products = initial_results["fingerprint"].map{|x| [x["vendor"], x["product"]] }.uniq


### PR DESCRIPTION
This PR adds the ability o use `require_vendor` on a fingerprint. The check for that fingerprint will only run if the vendor is matched before.