### PR TITLE
fixes an issue where cookies are returned as array

### DIFF
--- a/lib/http/matchers.rb
+++ b/lib/http/matchers.rb
@@ -17,8 +17,10 @@ module Matchers
     title_string = title_match.captures.first.strip if title_match
 
     # grab the set cookie header
-    set_cookie_header = "#{(hash[:response_headers]||[]).select{|x| x =~ /^set-cookie:(.*)/i}.first}".gsub("set-cookie:","").strip
-
+    ### note: the cookies in hash[:response_headers] can be an array or just a string, which is why we call .flatten on it
+    ### when multiple cookies are given (as an array), we join them first for comprehensive fingerprint checking
+    set_cookie_header = (hash[:response_headers]||[]).flatten.select{|x| x =~ /^set-cookie:(.*)/i}.join(";").gsub("set-cookie:","").strip
+      
     data = hash.merge({
       "details" =>  {
         "hidden_response_data" => "#{hash[:response_body]}",


### PR DESCRIPTION
This PR fixes an issue when multiple cookies are returned in an array (nested inside the response_headers array). We now flatten the array first, and then join all cookies. The joining ensures we are not missing any fingerprints.

This has been tested against endpoints known to have one, multiple and no cookies at all. It seems to be working fine and not throwing any errors. There are also more fingerprints returned, since we now use all cookies for matching.