### PR TITLE
Dockerfile Modification: package is missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN adduser --disabled-password --gecos "" ident \
     && apt-get install -yq apt-utils build-essential curl gcc \
        libbison-dev libcurl4-openssl-dev libgdbm-compat-dev libgdbm-dev \
        libgmp-dev libharfbuzz-dev libssl-dev libxml2-dev libxslt1-dev openssl \
-       readline-common  \
+       readline-common git \
     && mkdir -p /src/ruby  \
     && cd /src/ruby \
     && curl -O https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz \


### PR DESCRIPTION
The system won't build without the git package being installed to install the recog library.