### PR TITLE
Refactor / cleanup & bump to 5.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    intrigue-ident (4.2.7)
+    intrigue-ident (5.0.0)
       dnsruby
       mongo
       murmurhash3

--- a/lib/dns/check_factory.rb
+++ b/lib/dns/check_factory.rb
@@ -1,23 +1,23 @@
 module Intrigue
-  module Ident
-    module Dns
-      class CheckFactory
+module Ident
+module Dns
+class CheckFactory
 
-        #
-        # Register a new handler
-        #
-        def self.register(klass)
-          @checks = [] unless @checks
-          @checks << klass if klass
-        end
-
-        #
-        # Provide the full list of checks
-        #
-        def self.checks
-          @checks
-        end
-      end
-    end
+  #
+  # Register a new handler
+  #
+  def self.register(klass)
+    @checks = [] unless @checks
+    @checks << klass if klass
   end
+
+  #
+  # Provide the full list of checks
+  #
+  def self.checks
+    @checks
+  end
+end
+end
+end
 end

--- a/lib/elastic_search/check_factory.rb
+++ b/lib/elastic_search/check_factory.rb
@@ -1,23 +1,23 @@
 module Intrigue
-  module Ident
-    module ElasticSearch
-      class CheckFactory
+module Ident
+module ElasticSearch
+  class CheckFactory
 
-        #
-        # Register a new handler
-        #
-        def self.register(klass)
-          @checks = [] unless @checks
-          @checks << klass if klass
-        end
+    #
+    # Register a new handler
+    #
+    def self.register(klass)
+      @checks = [] unless @checks
+      @checks << klass if klass
+    end
 
-        #
-        # Provide the full list of checks
-        #
-        def self.checks
-          @checks
-        end
-      end
+    #
+    # Provide the full list of checks
+    #
+    def self.checks
+      @checks || []
     end
   end
+end
+end
 end

--- a/lib/ftp/check_factory.rb
+++ b/lib/ftp/check_factory.rb
@@ -3,20 +3,20 @@ module Ident
 module Ftp
 class CheckFactory
 
-    #
-    # Register a new handler
-    #
-    def self.register(klass)
-      @checks = [] unless @checks
-      @checks << klass if klass
-    end
+  #
+  # Register a new handler
+  #
+  def self.register(klass)
+    @checks = [] unless @checks
+    @checks << klass if klass
+  end
 
-    #
-    # Provide the full list of checks
-    #
-    def self.checks
-      @checks
-    end
+  #
+  # Provide the full list of checks
+  #
+  def self.checks
+    @checks
+  end
 
 end
 end

--- a/lib/http/check_factory.rb
+++ b/lib/http/check_factory.rb
@@ -3,61 +3,61 @@ module Ident
 module Http
 class CheckFactory
 
-    #
-    # Register a new handler
-    #
-    def self.register(klass)
-      @checks = [] unless @checks
-      @checks << klass if klass
-    end
+  #
+  # Register a new handler
+  #
+  def self.register(klass)
+    @checks = [] unless @checks
+    @checks << klass if klass
+  end
 
-    #
-    # Provide the full list of checks
-    #
-    def self.checks
-      @checks
-    end
+  #
+  # Provide the full list of checks
+  #
+  def self.checks
+    @checks
+  end
 
-    #
-    # Provide the full list of checks
-    #
-    def self.generate_initial_checks(url)
-      @checks.map{ |x| x.new.generate_checks("#{url}") }.flatten.compact.select{|x| 
-        x[:require_product] == nil && x[:require_vendor] == nil && x[:require_vendor_product] == nil }
-    end
+  #
+  # Provide the full list of checks
+  #
+  def self.generate_initial_checks(url)
+    @checks.map{ |x| x.new.generate_checks("#{url}") }.flatten.compact.select{|x|
+      x[:require_product] == nil && x[:require_vendor] == nil && x[:require_vendor_product] == nil }
+  end
 
-    #
-    # Provide checks given a vendor
-    #
-    def self.generate_checks_for_vendor(url,vendor)
-      @checks.map{ |x| x.new.generate_checks("#{url}") }.flatten.compact.select{|x| 
-        x[:require_vendor] == "#{vendor}" }
-    end
-    
-    #
-    # Provide checks givene a product
-    #
-    def self.generate_checks_for_product(url,product)
-      @checks.map{ |x| x.new.generate_checks("#{url}") }.flatten.compact.select{|x| 
-        x[:require_product] == "#{product}" }
-    end
+  #
+  # Provide checks given a vendor
+  #
+  def self.generate_checks_for_vendor(url,vendor)
+    @checks.map{ |x| x.new.generate_checks("#{url}") }.flatten.compact.select{|x|
+      x[:require_vendor] == "#{vendor}" }
+  end
 
-
-    #
-    # Provide checks givene a vendor product
-    #
-    def self.generate_checks_for_vendor_product(url, vendor, product)
-      @checks.map{ |x| x.new.generate_checks("#{url}") }.flatten.compact.select{|x| 
-        x[:require_vendor_product] == "#{vendor}_#{product}".downcase.gsub(" ","_") }
-    end
+  #
+  # Provide checks givene a product
+  #
+  def self.generate_checks_for_product(url,product)
+    @checks.map{ |x| x.new.generate_checks("#{url}") }.flatten.compact.select{|x|
+      x[:require_product] == "#{product}" }
+  end
 
 
-    #
-    # Provide the full list of checks
-    #
-    def self.configuration_checks
-      @checks.map{ |x| x.new.generate_checks("") }.flatten.compact.select{|x| x[:type] == "content" }
-    end
+  #
+  # Provide checks givene a vendor product
+  #
+  def self.generate_checks_for_vendor_product(url, vendor, product)
+    @checks.map{ |x| x.new.generate_checks("#{url}") }.flatten.compact.select{|x|
+      x[:require_vendor_product] == "#{vendor}_#{product}".downcase.gsub(" ","_") }
+  end
+
+
+  #
+  # Provide the full list of checks
+  #
+  def self.configuration_checks
+    @checks.map{ |x| x.new.generate_checks("") }.flatten.compact.select{|x| x[:type] == "content" }
+  end
 
 
 end

--- a/lib/http/http.rb
+++ b/lib/http/http.rb
@@ -4,8 +4,8 @@ module Intrigue
 module Ident
 module Http
 
-  # gives us the recog http matchers 
-  include Intrigue::Ident::RecogWrapper::Http 
+  # gives us the recog http matchers
+  include Intrigue::Ident::RecogWrapper::Http
 
   # Used by intrigue-core... note that this will currently fail unless
   def generate_http_requests_and_check(url, opts={})
@@ -18,7 +18,7 @@ module Http
     # this will look like an array of checks, each with a uri and a set of checks
     initial_checks = Intrigue::Ident::Http::CheckFactory.generate_initial_checks("#{url}")
 
-    ##### 
+    #####
     ##### Sanity check!
     #####
     failing_checks = initial_checks.select{|x| x if !x[:paths] }
@@ -41,7 +41,7 @@ module Http
       c.merge({:unique_path => p[:path], :follow_redirects => p[:follow_redirects] }).except(:paths) }}.flatten
 
     # now we have them organized by a single path, group them up so we only
-    # have to make a single request per unique path 
+    # have to make a single request per unique path
     grouped_initial_checks = initial_checks_by_path.group_by{|x| [ x[:unique_path], x[:follow_redirects] ]  }
 
     # allow us to only select the base path (speeds things up)
@@ -60,19 +60,19 @@ module Http
     #first_response = initial_results["responses"].first
     #if first_response && first_response[:response_headers]
     #  server_headers = first_response[:response_headers].select{|x| x =~ /^server:.*$/i }
-    #  if server_headers.count > 0 
+    #  if server_headers.count > 0
     #    recog_results << recog_match_http_server_banner(server_headers.first)
     #  end
     #
     #  cookies_headers = first_response[:response_headers].select{|x| x =~ /^set-cookie:.*$/i }
-    #  if cookies_headers.count > 0 
+    #  if cookies_headers.count > 0
     #    recog_results << recog_match_http_cookies(cookies_headers.first)
     #  end
     #end
 
     ###
     ### Follow-on Checks
-    ### 
+    ###
 
     ### Okay so, now we have a set of detected products, let's figure out our follown checks by product
     followon_checks = []
@@ -86,12 +86,12 @@ module Http
     detected_products.each do |vendor|
       followon_checks.concat(Intrigue::Ident::Http::CheckFactory.generate_checks_for_vendor("#{url}", vendor))
     end
-   
+
     ### Okay so, now we have a set of detected products, let's figure out our follown checks by vendor_product
     detected_vendor_products = initial_results["fingerprint"].map{|x| [x["vendor"], x["product"]] }.uniq
     detected_vendor_products.each do |vendor, product|
       followon_checks.concat(Intrigue::Ident::Http::CheckFactory.generate_checks_for_vendor_product("#{url}", vendor, product))
-    end    
+    end
 
     # group them up by path (there can be multiple paths)
     followon_checks_by_path = followon_checks.map{|c| c[:paths].map{ |p|
@@ -99,7 +99,7 @@ module Http
 
     # group'm as needed to run the checks
     grouped_followon_checks = followon_checks_by_path.group_by{|x| [ x[:unique_path], x[:follow_redirects] ] }
-    
+
     # allow us to only select the base path (speeds things up)
     if only_base
       grouped_followon_checks = grouped_followon_checks.select{|x,y| x == url}
@@ -110,13 +110,13 @@ module Http
       followon_results = run_grouped_http_checks(url, grouped_followon_checks, dom_checks, debug)
     else
       followon_results = {
-        "fingerprint" => [], 
+        "fingerprint" => [],
         "content" => [],
         "responses" => [],
         "check_count" => []
       }
     end
-  
+
     ###
     ### Generate output
     ###
@@ -129,7 +129,7 @@ module Http
       "followon_checks" => followon_results["check_count"]
     }
 
-  out 
+  out
   end
 
   private
@@ -151,27 +151,27 @@ module Http
       target_url = ggc.first
 
       # TODO ... this should probably be a hash
-      follow_redirects = ggc.last 
+      follow_redirects = ggc.last
 
       if timeout_count > 2
         puts "Skipping #{target_url}, too many timeouts" if debug
-        next 
+        next
       end
-      
+
       # get the response using a normal http request
       puts "Getting #{target_url}" if debug
       response_hash = ident_http_request :get, "#{target_url}", nil, {}, nil, follow_redirects
-    
+
       if response_hash[:timeout]
         puts "ERROR timed out on #{target_url}" if debug
         timeout_count += 1
-      end 
+      end
 
       responses << response_hash
 
       # Go ahead and match it up if we got a response!
       if response_hash
-        
+
         # call each check, collecting the product if it's a match
         ###
         ### APPLY THE IDENT!
@@ -180,7 +180,7 @@ module Http
 
           # if we have a check that should match the dom, run it
           if (check[:match_type] == :content_dom)
-             # skip it, no longer supported. 
+             # skip it, no longer supported.
           else #otherwise use the normal flow
             results << match_http_response_hash(check,response_hash)
           end
@@ -204,7 +204,7 @@ module Http
 
     # attach the responses
     out["responses"] = responses
-    
+
   out
   end
 
@@ -222,21 +222,21 @@ module Http
       headers["User-Agent"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
     end
 
-    begin 
+    begin
 
       options = {}
 
       # always
       options[:timeout] = timeout
       options[:ssl_verifyhost] = 0
-      options[:ssl_verifypeer] = false 
+      options[:ssl_verifypeer] = false
 
       # follow redirects if we're told
-      if follow_redirects 
+      if follow_redirects
         options[:followlocation] = true
       end
 
-      # if we're a post, set our body 
+      # if we're a post, set our body
       if method == :post
         options[:body] = data
       end
@@ -252,7 +252,7 @@ module Http
         headers: headers
       }.merge!(options))
 
-      # run the request 
+      # run the request
       response = request.run
 
     # catch th
@@ -268,11 +268,11 @@ module Http
       else
         puts "Unable to get a response"
       end
-      return nil 
+      return nil
     end
 
     #scheme = "#{response.port}" =~ /443/ ? "https" : "http"
-    
+
     # generate our output
     out = {
       :options => options,

--- a/lib/ident.rb
+++ b/lib/ident.rb
@@ -28,6 +28,8 @@ end
 
 # load in generic utils
 require_relative "utils"
+include Intrigue::Ident::Utils
+
 require_relative "version"
 
 ###
@@ -239,61 +241,283 @@ Encoding.default_internal = Encoding::UTF_8
 $ident_dir = File.expand_path("../", File.dirname(__FILE__))
 
 module Intrigue
-  module Ident
-    private
+module Ident
+class Ident
 
-    def _sanitize_string(string)
-      # return nil if string is empty, to allow valid version comparison.
-      return nil if string == "" || string == nil
+  # list all checks
+  def list_checks(path="[URI]")
+    Intrigue::Ident::Http::CheckFactory.checks.map { |x| x.new.generate_checks(path)
+    }.concat(
+      Intrigue::Ident::Dns::CheckFactory.checks.map { |x| x.new.generate_checks }
+    ).concat(
+      Intrigue::Ident::ElasticSearch::CheckFactory.checks.map { |x| x.new.generate_checks }
+    ).concat(
+      Intrigue::Ident::Ftp::CheckFactory.checks.map { |x| x.new.generate_checks }
+    ).concat(
+      Intrigue::Ident::Imap::CheckFactory.checks.map { |x| x.new.generate_checks }
+    ).concat(
+      Intrigue::Ident::MongoDb::CheckFactory.checks.map { |x| x.new.generate_checks }
+    ).concat(
+      Intrigue::Ident::Mysql::CheckFactory.checks.map { |x| x.new.generate_checks }
+    ).concat(
+      Intrigue::Ident::Pop3::CheckFactory.checks.map { |x| x.new.generate_checks }
+    ).concat(
+      Intrigue::Ident::Redis::CheckFactory.checks.map { |x| x.new.generate_checks }
+    ).concat(
+      Intrigue::Ident::Smtp::CheckFactory.checks.map { |x| x.new.generate_checks }
+    ).concat(
+      Intrigue::Ident::Snmp::CheckFactory.checks.map { |x| x.new.generate_checks }
+    ).concat(
+      Intrigue::Ident::Ssh::CheckFactory.checks.map { |x| x.new.generate_checks }
+    ).concat(
+      Intrigue::Ident::Telnet::CheckFactory.checks.map { |x| x.new.generate_checks }
+    ).flatten
+  end
 
-      "#{string}".encode("UTF-8", invalid: :replace, undef: :replace, replace: "?")
+  # This is the main  interface for interaction going foward!!!
+  #
+  # Fingerprint by uri
+  #
+  def fingerprint_uri(uri, opts={})
+    x = URI.parse(uri)
+    port = x.port || _service_to_port(x.scheme)
+    hostname = x.host
+
+    fingerprint_service(hostname, port, opts)
+  end
+
+  # Fingerprint by hostname and port
+  #
+  def fingerprint_service(ip_address_or_hostname, port, opts={})
+
+    ident_matches = nil
+
+    if (port == 53 || port =~ /^[\d]+53$/)
+      ident_matches = generate_dns_request_and_check(ip_address_or_hostname) || {}
     end
 
-    def _construct_match_response(check, data)
-      if check[:type] == "fingerprint"
-        calculated_product = _sanitize_string((check[:dynamic_product].call(data) if check[:dynamic_product]) || check[:product])
-        calculated_version = _sanitize_string((check[:dynamic_version].call(data) if check[:dynamic_version]) || check[:version])
-        calculated_update = _sanitize_string((check[:dynamic_update].call(data) if check[:dynamic_update]) || check[:update])
+    if (port == 9200 || port =~ /^[\d]?920\d$/)
+      ident_matches = generate_elastic_search_request_and_check(ip_address_or_hostname) || {}
+    end
 
-        calculated_type = "a" if check[:category] == "application"
-        calculated_type = "h" if check[:category] == "hardware"
-        calculated_type = "o" if check[:category] == "operating_system"
-        calculated_type = "s" if check[:category] == "service" # literally made up
+    if (port == 21 || port =~ /^[\d]+21$/)
+      ident_matches = generate_ftp_request_and_check(ip_address_or_hostname) || {}
+    end
 
-        vendor_string = check[:vendor].gsub(" ", "_") if check[:vendor]
-        product_string = calculated_product.gsub(" ", "_") if calculated_product
+    if (port == 80 || port =~ /^[\d]+80$/)
+      ident_matches = generate_http_requests_and_check(ip_address_or_hostname, opts) || {}
+    end
 
-        version = "#{calculated_version}".gsub(" ", "_")
-        update = "#{calculated_update}".gsub(" ", "_")
+    if (port == 443 || port =~ /^[\d]+443$/)
+      ident_matches = generate_http_requests_and_check(ip_address_or_hostname, opts) || {}
+    end
 
-        cpe_string = _sanitize_string("cpe:2.3:#{calculated_type}:#{vendor_string}:#{product_string}:#{version}:#{update}".downcase)
+    if (port == 143 || port =~ /^[\d]+143$/)
+      ident_matches = generate_imap_request_and_check(ip_address_or_hostname) || {}
+    end
+
+    if (port == 27017)
+      ident_matches = generate_mongodb_request_and_check(ip_address_or_hostname) || {}
+    end
+
+    if (port == 3306 || port =~ /^[\d]+3306$/)
+      ident_matches = generate_mysql_request_and_check(ip_address_or_hostname) || {}
+    end
+
+    if (port == 110 || port =~ /^[\d]+110$/ )
+      ident_matches = generate_pop3_request_and_check(ip_address_or_hostname) || {}
+    end
+
+    if port == 6379 || port =~ /^\d?6379$/
+      ident_matches = generate_redis_request_and_check(ip_address_or_hostname) || {}
+    end
+
+    if (port == 25 || port =~ /^\d+25$/) #587?
+      ident_matches = generate_smtp_request_and_check(ip_address_or_hostname) || {}
+    end
+
+    if (port == 161 || port =~ /^\d+161$/)
+      ident_matches = generate_snmp_request_and_check(ip_address_or_hostname) || {}
+    end
+
+    if (port == 22 || port =~ /^[\d]+22$/)
+      ident_matches = generate_ssh_request_and_check(ip_address_or_hostname) || {}
+    end
+
+    if (port == 23 || port =~ /^[\d]+23$/)
+      ident_matches = generate_telnet_request_and_check(ip_address_or_hostname) || {}
+    end
+
+    ###
+    ### But default to HTTP through each known port
+    ###
+    if ident_matches
+      return ident_matches # return right away if we a FP
+    else
+      url = "http://#{ip_address_or_hostname}:#{port}"
+      ident_matches = generate_http_requests_and_check(url, opts) || {}
+
+      # if we didnt fail, pull out the FP and match to vulns
+      ident_fingerprints = ident_matches["fingerprint"] || []
+
+      # merge them
+      out = ident_matches.merge({"fingerprint" => ident_fingerprints})
+    end
+
+  out
+  end
+
+  private
+
+  def _service_to_port(service_name)
+    case service_name
+    when "dns"
+      53
+    when "elasticsearch"
+      9200
+    when "ftp"
+      21
+    when "http"
+      80
+    when "https"
+      443
+    when "imap"
+      143
+    when "mongodb"
+      27017
+    when "mysql"
+      143
+    when "pop3"
+      143
+    when "redis"
+      143
+    when "smtp"
+      143
+    when "snmp"
+      161
+    when "ssh"
+      22
+    when "telnet"
+      23
+    else
+      raise "Unkown service"
+    end
+  end
+
+
+
+  def _sanitize_string(string)
+    # return nil if string is empty, to allow valid version comparison.
+    return nil if string == "" || string == nil
+
+    "#{string}".encode("UTF-8", invalid: :replace, undef: :replace, replace: "?")
+  end
+
+  def _construct_match_response(check, data)
+
+    if check[:type] == "fingerprint"
+      calculated_product = _sanitize_string((check[:dynamic_product].call(data) if check[:dynamic_product]) || check[:product])
+      calculated_version = _sanitize_string((check[:dynamic_version].call(data) if check[:dynamic_version]) || check[:version])
+      calculated_update = _sanitize_string((check[:dynamic_update].call(data) if check[:dynamic_update]) || check[:update])
+
+      calculated_type = "a" if check[:category] == "application"
+      calculated_type = "h" if check[:category] == "hardware"
+      calculated_type = "o" if check[:category] == "operating_system"
+      calculated_type = "s" if check[:category] == "service" # literally made up
+
+      vendor_string = check[:vendor].gsub(" ", "_") if check[:vendor]
+      product_string = calculated_product.gsub(" ", "_") if calculated_product
+
+      version = "#{calculated_version}".gsub(" ", "_")
+      update = "#{calculated_update}".gsub(" ", "_")
+
+      cpe_string = _sanitize_string("cpe:2.3:#{calculated_type}:#{vendor_string}:#{product_string}:#{version}:#{update}".downcase)
+
+      ##
+      # Support for Dynamic Product
+      ##
+      if check[:dynamic_product]
+        calculated_product = check[:dynamic_product].call(data)
+      elsif check[:product] # also handle singular
+        calculated_product = check[:product]
+      end
+
+      ##
+      # Support for Dynamic Issues
+      ##
+      if check[:dynamic_issues]
+        issues = check[:dynamic_issues].call(data)
+      elsif check[:dynamic_issue] # also handle singular
+        issues = [check[:dynamic_issues].call(data)]
+      elsif check[:issues]
+        issues = check[:issues]
+      elsif check[:issue] # also handle singular
+        issues = [check[:issue]]
+      else
+        issues = nil
+      end
+
+      ##
+      # Support for Dynamic Hide
+      ##
+      if check[:dynamic_hide]
+        hide = check[:dynamic_hide].call(data)
+      elsif check[:hide]
+        hide = check[:hide]
+      else
+        hide = false
+      end
+
+      ##
+      # Support for Dynamic Task
+      ##
+      if check[:dynamic_tasks]
+        tasks = check[:dynamic_tasks].call(data)
+      elsif check[:tasks]
+        tasks = check[:tasks]
+      else
+        tasks = nil
+      end
+
+      to_return = {
+        "method" => "ident",
+        "type" => check[:type],
+        "vendor" => check[:vendor],
+        "product" => calculated_product,
+        "version" => calculated_version,
+        "update" => calculated_update,
+        "tags" => check[:tags],
+        "match_type" => check[:match_type],
+        "description" => check[:description],
+        "hide" => hide,
+        "cpe" => cpe_string,
+        "issues" => issues,
+        "tasks" => tasks, # [{ :task_name => "example", :task_options => {}}]
+        "inference" => check[:inference],
+      }
+    elsif check[:type] == "content"
+
+      # Mandatory lambda
+      result = check[:dynamic_result].call(data)
+
+      ##
+      ## Support for Dynamic Issue (must be dynamic, these checks always run)
+      ##
+      if result
 
         ##
-        # Support for Dynamic Product
+        ## Support for Dynamic
         ##
-        if check[:dynamic_product]
-          calculated_product = check[:dynamic_product].call(data)
-        elsif check[:product] # also handle singular
-          calculated_product = check[:product]
-        end
-
-        ##
-        # Support for Dynamic Issues
-        ##
-        if check[:dynamic_issues]
-          issues = check[:dynamic_issues].call(data)
-        elsif check[:dynamic_issue] # also handle singular
-          issues = [check[:dynamic_issues].call(data)]
-        elsif check[:issues]
-          issues = check[:issues]
-        elsif check[:issue] # also handle singular
-          issues = [check[:issue]]
+        if check[:dynamic_issue]
+          issue = check[:dynamic_issue].call(data)
+        elsif check[:issue]
+          issue = check[:issue]
         else
-          issues = nil
+          issue = nil
         end
 
         ##
-        # Support for Dynamic Hide
+        ## Support for Dynamic Hide
         ##
         if check[:dynamic_hide]
           hide = check[:dynamic_hide].call(data)
@@ -304,74 +528,14 @@ module Intrigue
         end
 
         ##
-        # Support for Dynamic Task
+        ## Support for Dynamic Task
         ##
-        if check[:dynamic_tasks]
-          tasks = check[:dynamic_tasks].call(data)
-        elsif check[:tasks]
-          tasks = check[:tasks]
+        if check[:dynamic_task]
+          task = check[:dynamic_task].call(data)
+        elsif check[:task]
+          task = check[:task]
         else
-          tasks = nil
-        end
-
-        to_return = {
-          "method" => "ident",
-          "type" => check[:type],
-          "vendor" => check[:vendor],
-          "product" => calculated_product,
-          "version" => calculated_version,
-          "update" => calculated_update,
-          "tags" => check[:tags],
-          "match_type" => check[:match_type],
-          "description" => check[:description],
-          "hide" => hide,
-          "cpe" => cpe_string,
-          "issues" => issues,
-          "tasks" => tasks, # [{ :task_name => "example", :task_options => {}}]
-          "inference" => check[:inference],
-        }
-      elsif check[:type] == "content"
-
-        # Mandatory lambda
-        result = check[:dynamic_result].call(data)
-
-        ##
-        ## Support for Dynamic Issue (must be dynamic, these checks always run)
-        ##
-        if result
-
-          ##
-          ## Support for Dynamic
-          ##
-          if check[:dynamic_issue]
-            issue = check[:dynamic_issue].call(data)
-          elsif check[:issue]
-            issue = check[:issue]
-          else
-            issue = nil
-          end
-
-          ##
-          ## Support for Dynamic Hide
-          ##
-          if check[:dynamic_hide]
-            hide = check[:dynamic_hide].call(data)
-          elsif check[:hide]
-            hide = check[:hide]
-          else
-            hide = false
-          end
-
-          ##
-          ## Support for Dynamic Task
-          ##
-          if check[:dynamic_task]
-            task = check[:dynamic_task].call(data)
-          elsif check[:task]
-            task = check[:task]
-          else
-            task = nil
-          end
+          task = nil
         end
 
         to_return = {
@@ -380,14 +544,25 @@ module Intrigue
           "hide" => hide,
           "issue" => issue,
           "task" => task,
-          "result" => "#{_sanitize_string(result)}",
+          "result" => result,
         }
+
+        # only return if not empty in this case
+        if result.kind_of?(Hash) || result.kind_of?(Array)
+          to_return = nil if result.empty?
+        end
+
+      else
+        to_return = nil
       end
 
-      to_return
     end
-  end
-end
 
-# always include
-include Intrigue::Ident
+  to_return
+  end
+
+
+
+end
+end
+end

--- a/lib/imap/check_factory.rb
+++ b/lib/imap/check_factory.rb
@@ -1,23 +1,23 @@
 module Intrigue
-  module Ident
-    module Imap
-      class CheckFactory
+module Ident
+module Imap
+  class CheckFactory
 
-        #
-        # Register a new handler
-        #
-        def self.register(klass)
-          @checks = [] unless @checks
-          @checks << klass if klass
-        end
+    #
+    # Register a new handler
+    #
+    def self.register(klass)
+      @checks = [] unless @checks
+      @checks << klass if klass
+    end
 
-        #
-        # Provide the full list of checks
-        #
-        def self.checks
-          @checks
-        end
-      end
+    #
+    # Provide the full list of checks
+    #
+    def self.checks
+      @checks || []
     end
   end
+end
+end
 end

--- a/lib/mongodb/check_factory.rb
+++ b/lib/mongodb/check_factory.rb
@@ -1,23 +1,23 @@
 module Intrigue
-  module Ident
-    module MongoDb
-      class CheckFactory
+module Ident
+module MongoDb
+class CheckFactory
 
-        #
-        # Register a new handler
-        #
-        def self.register(klass)
-          @checks = [] unless @checks
-          @checks << klass if klass
-        end
-
-        #
-        # Provide the full list of checks
-        #
-        def self.checks
-          @checks
-        end
-      end
-    end
+  #
+  # Register a new handler
+  #
+  def self.register(klass)
+    @checks = [] unless @checks
+    @checks << klass if klass
   end
+
+  #
+  # Provide the full list of checks
+  #
+  def self.checks
+    @checks || []
+  end
+end
+end
+end
 end

--- a/lib/mysql/check_factory.rb
+++ b/lib/mysql/check_factory.rb
@@ -3,20 +3,20 @@ module Ident
 module Mysql
 class CheckFactory
 
-    #
-    # Register a new handler
-    #
-    def self.register(klass)
-      @checks = [] unless @checks
-      @checks << klass if klass
-    end
+  #
+  # Register a new handler
+  #
+  def self.register(klass)
+    @checks = [] unless @checks
+    @checks << klass if klass
+  end
 
-    #
-    # Provide the full list of checks
-    #
-    def self.checks
-      @checks
-    end
+  #
+  # Provide the full list of checks
+  #
+  def self.checks
+    @checks
+  end
 
 end
 end

--- a/lib/mysql/mysql.rb
+++ b/lib/mysql/mysql.rb
@@ -19,7 +19,7 @@ module Intrigue
         details = {
           "details" => {
             #"banner" => nil, #banner_string
-            "error" => error_string,
+            "error" => error_string
           },
         }
 

--- a/lib/pop3/check_factory.rb
+++ b/lib/pop3/check_factory.rb
@@ -1,23 +1,23 @@
 module Intrigue
-  module Ident
-    module Pop3
-      class CheckFactory
+module Ident
+module Pop3
+class CheckFactory
 
-        #
-        # Register a new handler
-        #
-        def self.register(klass)
-          @checks = [] unless @checks
-          @checks << klass if klass
-        end
-
-        #
-        # Provide the full list of checks
-        #
-        def self.checks
-          @checks
-        end
-      end
-    end
+  #
+  # Register a new handler
+  #
+  def self.register(klass)
+    @checks = [] unless @checks
+    @checks << klass if klass
   end
+
+  #
+  # Provide the full list of checks
+  #
+  def self.checks
+    @checks
+  end
+end
+end
+end
 end

--- a/lib/redis/check_factory.rb
+++ b/lib/redis/check_factory.rb
@@ -3,20 +3,20 @@ module Ident
 module Redis
 class CheckFactory
 
-    #
-    # Register a new handler
-    #
-    def self.register(klass)
-      @checks = [] unless @checks
-      @checks << klass if klass
-    end
+  #
+  # Register a new handler
+  #
+  def self.register(klass)
+    @checks = [] unless @checks
+    @checks << klass if klass
+  end
 
-    #
-    # Provide the full list of checks
-    #
-    def self.checks
-      @checks
-    end
+  #
+  # Provide the full list of checks
+  #
+  def self.checks
+    @checks
+  end
 
 end
 end

--- a/lib/smtp/check_factory.rb
+++ b/lib/smtp/check_factory.rb
@@ -3,20 +3,20 @@ module Ident
 module Smtp
 class CheckFactory
 
-    #
-    # Register a new handler
-    #
-    def self.register(klass)
-      @checks = [] unless @checks
-      @checks << klass if klass
-    end
+  #
+  # Register a new handler
+  #
+  def self.register(klass)
+    @checks = [] unless @checks
+    @checks << klass if klass
+  end
 
-    #
-    # Provide the full list of checks
-    #
-    def self.checks
-      @checks
-    end
+  #
+  # Provide the full list of checks
+  #
+  def self.checks
+    @checks
+  end
 
 end
 end

--- a/lib/snmp/check_factory.rb
+++ b/lib/snmp/check_factory.rb
@@ -3,20 +3,20 @@ module Ident
 module Snmp
 class CheckFactory
 
-    #
-    # Register a new handler
-    #
-    def self.register(klass)
-      @checks = [] unless @checks
-      @checks << klass if klass
-    end
+  #
+  # Register a new handler
+  #
+  def self.register(klass)
+    @checks = [] unless @checks
+    @checks << klass if klass
+  end
 
-    #
-    # Provide the full list of checks
-    #
-    def self.checks
-      @checks
-    end
+  #
+  # Provide the full list of checks
+  #
+  def self.checks
+    @checks
+  end
 
 end
 end

--- a/lib/ssh/check_factory.rb
+++ b/lib/ssh/check_factory.rb
@@ -3,20 +3,20 @@ module Ident
 module Ssh
 class CheckFactory
 
-    #
-    # Register a new handler
-    #
-    def self.register(klass)
-      @checks = [] unless @checks
-      @checks << klass if klass
-    end
+  #
+  # Register a new handler
+  #
+  def self.register(klass)
+    @checks = [] unless @checks
+    @checks << klass if klass
+  end
 
-    #
-    # Provide the full list of checks
-    #
-    def self.checks
-      @checks
-    end
+  #
+  # Provide the full list of checks
+  #
+  def self.checks
+    @checks
+  end
 
 end
 end

--- a/lib/telnet/check_factory.rb
+++ b/lib/telnet/check_factory.rb
@@ -3,20 +3,20 @@ module Ident
 module Telnet
 class CheckFactory
 
-    #
-    # Register a new handler
-    #
-    def self.register(klass)
-      @checks = [] unless @checks
-      @checks << klass if klass
-    end
+  #
+  # Register a new handler
+  #
+  def self.register(klass)
+    @checks = [] unless @checks
+    @checks << klass if klass
+  end
 
-    #
-    # Provide the full list of checks
-    #
-    def self.checks
-      @checks
-    end
+  #
+  # Provide the full list of checks
+  #
+  def self.checks
+    @checks
+  end
 
 end
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Ident
-  VERSION = "4.2.8"
+  VERSION = "5.0.0"
 end

--- a/util/ident.rb
+++ b/util/ident.rb
@@ -3,30 +3,177 @@ require_relative "../lib/ident"
 require "slop"
 require "thread"
 
-include Intrigue::Ident
-include Intrigue::Ident::Utils
+def print(string)
+  puts "#{string}" unless @json
+end
 
-def check_file_uris(opts)
+def print_debug(string)
+  puts "[D] #{string}" if @debug && !@json
+end
+
+def main
+  begin
+
+    ###
+    ### Parse options
+    ###
+    opts = Slop.parse do |o|
+
+      # url input
+      o.string "-u", "--uri", "a uri to check (supported portocols: " +
+        "(dns, elasticsearch, ftp, http, https, imap, mongodb, mysql, pop3, redis, smtp, snmp, telnet) " +
+        "ex: http://intrigue.io"
+      o.string "-f", "--file", "a file of urls, one per line"
+
+      # export
+      #o.bool '--csv', 'export to csv'
+      o.bool "-j", "--json", "export to json"
+
+      # behavior
+      o.string "-i", "--include", "include checks from this directory (can be used multiple times)"
+      o.integer "-t", "--threads", "number of threads to use when checking a file (default: 3)"
+      o.bool "-v", "--vulnerabilities", "query intrigue.io api for top vulnerabilities"
+      o.bool "-c", "--content", "show content checks"
+      o.bool "-b", "--only-check-base-url", "only base url "
+      o.bool "-d", "--debug", "enable debug mode"
+      o.bool "-l", "--list", "list all checks"
+
+      o.on "-h", "--help" do
+        print o
+        exit
+      end
+
+      o.on "--version", "print the version" do
+        print Ident::VERSION
+        exit
+      end
+
+    end
+  rescue Slop::MissingArgument => e
+    print "Error! #{e}"
+    return
+  end
+
+  # convert to a hash
+  opts = opts.to_hash
+
+  # set json as a variable
+  if opts[:json]
+    @json = opts[:json]
+  end
+
+  # set debug as a variable
+  if opts[:debug]
+    @debug = opts[:debug]
+  end
+
+  ###
+  ## include external checks
+  ###
+  if opts[:include]
+    # follow directory structure from ident
+    checks = Dir.glob("#{opts[:include]}/checks/*.rb")
+    checks += Dir.glob("#{opts[:include]}/checks/*/*.rb")
+    checks += Dir.glob("#{opts[:include]}/checks/*/*/*.rb")
+    print_debug "Requiring #{checks.count} files from include path: #{opts[:include]}"
+    checks.each do |p|
+      require p
+    end
+  end
+
+  if opts[:'list']
+    print "Fingerprint, Version Detection, Hide By Default, Issues, Vulnerability Inference, Tags"
+    ident = Intrigue::Ident::Ident.new
+    ident.list_checks.sort_by { |c| "#{c[:type]}" }.each do |c|
+      next unless c[:type] == "fingerprint"
+      out = ""
+      out << "#{c[:name]} #{c[:vendor]} #{c[:product]} #{c[:version]}".gsub(",", "") + ", "
+      out << "#{!c[:dynamic_version].nil?}, "
+      out << "#{c[:hide]}, "
+      out << "#{(c[:issues].join(" | ") if c[:issues]) || c[:issue]}, "
+      out << "#{c[:inference]}, "
+      #out << "#{c[:paths].join(" | ") if c[:paths]}, "
+      out << "#{c[:tags].join(" | ") if c[:tags]}"
+      print out
+    end
+    return # so we don't hit the next gate
+  end
+
+  unless opts[:uri] || opts[:file] || opts[:list-checks]
+    print "Error! At least one of --list, --file or --uri must be specified"
+    return
+  end
+
+  ## handle url input
+  if opts[:uri]
+    print_debug "Checking URL: #{opts[:uri]}"
+    check_single_uri(opts)
+  end
+
+  ## handle file input
+  if opts[:file]
+    print_debug "Checking File: #{opts[:file]}"
+    check_uris_from_file(opts)
+  end
+end
+
+
+# Write the file (helper method)
+def write_simple_csv(filename, output_q)
+  headings = []
+  headings << "URL"
+  headings << "Fingerprint"
+  headings << "Match Details"
+  File.open(filename, "w") { |f| f.print headings.join(", ") }
+
+  while output_q.size > 0
+
+    # get a result
+    o = output_q.pop
+
+    # get our url, fingerprint and tags
+    out = ""
+    o["fingerprint"].uniq.map do |f|
+      out << "#{o["url"]}, "
+      out << "#{f["vendor"]} #{f["product"]} #{f["version"]} #{f["update"]}".strip << ", "
+      out << "#{f["description"]} "
+      out << "\n"
+    end
+
+    # print it out!
+    File.open(filename, "a") { |f| f.print out }
+  end
+
+  print
+  print "============================"
+  print "Find results in: #{filename}"
+  print "============================"
+end
+
+
+def check_uris_from_file(opts)
   filepath = opts[:file]
-  debug = opts[:debug]
 
   # push all urls into a queue
   work_q = Queue.new
   output_q = Queue.new
 
-  puts "Parsing file #{filepath}" if debug
+  print_debug "Parsing file #{filepath}"
   File.open(filepath, "r").each_line { |x| work_q << x.chomp }
 
-  #puts "Checking: #{work_q.inspect}" if debug
+  # create a new ident obj
+  ident_obj = Intrigue::Ident::Ident.new
+
   num_threads = opts[:threads] || 3
   workers = (0...num_threads).map do
     Thread.new do
       begin
         while x = work_q.pop(true)
           thread_name = "thread-#{rand(9999999)}"
-          puts "#{thread_name} checking: #{x}" if debug
+          print_debug "#{thread_name} checking: #{x}"
 
-          check_result = generate_http_requests_and_check(x, opts)
+          #check_result = generate_http_requests_and_check(x, opts)
+          check_result = ident_obj.fingerprint_uri(x)
 
           out = {}
           out["url"] = check_result["url"]
@@ -51,14 +198,14 @@ def check_file_uris(opts)
             end
           end
 
-          puts "#{thread_name} #{x} gave result: #{out}" if debug
+          print_debug "#{thread_name} #{x} gave result: #{out}"
 
           output_q << out
         end # while
       rescue StandardError => e
-        puts "Caught Exception! #{e}" if debug
+        print_debug "Caught Exception! #{e}"
       rescue ThreadError
-        puts "Caught Exception! #{e}" if debug
+        print_debug "Caught Exception! #{e}"
       end # begin
     end # thread
   end; "ok" # workers
@@ -69,243 +216,68 @@ def check_file_uris(opts)
 end
 
 def check_single_uri(opts)
+
+  print_debug "Options: #{opts}"
   query_vulns = opts[:vulnerabilities] || false
-  debug = opts[:debug]
-  json = opts[:json] || false
 
   if uri = opts[:uri]
     if uri =~ /^http[s]?:\/\/.*$/
-      check_result = generate_http_requests_and_check(uri, opts)
-      if debug
-        puts "Ran #{check_result["initial_checks"].first["count"]} initial checks against base URL"
+
+      check_result = Intrigue::Ident::Ident.new.fingerprint_uri(uri)
+      if @debug
+        print_debug "Ran #{check_result["initial_checks"].first["count"]} initial checks against base URL"
         if !check_result["followon_checks"].empty?
-          puts "Also checked the following urls due to initial fingerprint:"
-          check_result["followon_checks"].each { |x| puts " - #{x["url"]}\n" }
+          print_debug "Also checked the following urls due to initial fingerprint:"
+          check_result["followon_checks"].each { |x| print_debug " - #{x["url"]}\n" }
         end
       end
+
     else # not http
       parsed_uri = URI(uri)
-
-      proto = "#{parsed_uri.scheme}".downcase
-      ip = parsed_uri.hostname
-      port = parsed_uri.port
-
-      puts "Checking ... PROTO: #{proto} | HOST: #{ip} | PORT: #{port || "default"}" if debug
-
-      if proto == "dns"
-        check_result = generate_dns_request_and_check(ip, port || 53)
-      elsif proto == "elasticsearch"
-        check_result = generate_elastic_search_request_and_check(ip, port || 9200)
-      elsif proto == "ftp"
-        check_result = generate_ftp_request_and_check(ip, port || 21)
-      elsif proto == "imap"
-        check_result = generate_imap_request_and_check(ip, port || 143)
-      elsif proto == "mongodb"
-        check_result = generate_mongodb_request_and_check(ip, port || 27017)
-      elsif proto == "mysql"
-        check_result = generate_mysql_request_and_check(ip, port || 3306)
-      elsif proto == "pop3"
-        check_result = generate_pop3_request_and_check(ip, port || 110)
-      elsif proto == "redis"
-        check_result = generate_redis_request_and_check(ip, port || 6379)
-      elsif proto == "snmp"
-        check_result = generate_smtp_request_and_check(ip, port || 25)
-      elsif proto == "ssh"
-        check_result = generate_snmp_request_and_check(ip, port || 161)
-      elsif proto == "smtp"
-        check_result = generate_ssh_request_and_check(ip, port || 22)
-      elsif proto == "telnet"
-        check_result = generate_telnet_request_and_check(ip, port || 23)
-      else
-        puts "Unable to parse URI (#{uri}). Check -h for supported protocols"
-        exit
-      end
+      print_debug "Checking ... #{parsed_uri}"
+      check_result = Intrigue::Ident::Ident.new.fingerprint_uri(uri)
     end
 
     unless check_result
-      puts "Internal Error! Unable to get matches!"
+      print_debug "Internal Error! Unable to get matches!"
       exit -1
     end
 
-    if check_result["fingerprint"] && !json
-      puts "Fingerprint: "
+    if check_result["fingerprint"] && !@json
+      print "Fingerprint: "
       uniq_matches = []
       check_result["fingerprint"].each do |x|
 
         # Print it out
-        puts " - #{x["vendor"]} #{x["product"]} #{x["version"]} #{x["update"]} - #{x["description"]} (CPE: #{x["cpe"]}) (Tags: #{x["tags"]}) (Hide: #{x["hide"]}) (Issues: #{x["issues"]}) (Tasks: #{x["tasks"]})"
+        print " - #{x["vendor"]} #{x["product"]} #{x["version"]} #{x["update"]} - #{x["description"]} (CPE: #{x["cpe"]}) (Tags: #{x["tags"]}) (Hide: #{x["hide"]}) (Issues: #{x["issues"]}) (Tasks: #{x["tasks"]})"
         if query_vulns
           vulns = Intrigue::Vulndb::Client.query(ENV["INTRIGUEIO_KEY"], x["cpe"]) || []
           vulns.sort_by { |x| x["cvss_v3_score"] || x["cvss_v2_score"] || 1 }.reverse.first(5).each do |v|
-            puts "   - Vuln: #{v["cve"]} (CVSS: #{v["cvss_v3_score"] || v["cvss_v2_score"]}) https://nvd.nist.gov/vuln/detail/#{v["cve"]}"
+            print "   - Vuln: #{v["cve"]} (CVSS: #{v["cvss_v3_score"] || v["cvss_v2_score"]}) https://nvd.nist.gov/vuln/detail/#{v["cve"]}"
           end
         end
       end
-    elsif !json
-      puts "No fingerprintable technologies discovered!"
+    elsif !@json
+      print "No fingerprintable technologies discovered!"
     end
 
     if opts[:content]
       if check_result["content"]
-        puts "Content Checks:"
+        print "Content Checks:"
         check_result["content"].each do |x|
-          puts " - #{x["name"]}: #{x["result"]}"
+          print " - #{x["name"]}: #{x["result"]}"
         end
       end
     end
 
-    puts JSON.pretty_generate(check_result) if json
   end
+
+  if @json
+    # Not print, since that's blocked on @json
+    puts JSON.pretty_generate(check_result)
+  end
+
 end
 
-# Write the file
-def write_simple_csv(output_q)
-  headings = []
-  headings << "URL"
-  headings << "Fingerprint"
-  headings << "Match Details"
-  File.open("output.csv", "w") { |f| f.puts headings.join(", ") }
-
-  while output_q.size > 0
-
-    # get a result
-    o = output_q.pop
-
-    # get our url, fingerprint and tags
-    out = ""
-    o["fingerprint"].uniq.map do |f|
-      out << "#{o["url"]}, "
-      out << "#{f["vendor"]} #{f["product"]} #{f["version"]} #{f["update"]}".strip << ", "
-      out << "#{f["description"]} "
-      out << "\n"
-    end
-
-    # print it out!
-    File.open("output.csv", "a") { |f| f.puts out }
-  end
-
-  puts
-  puts "============================"
-  puts "Find results in: output.csv"
-  puts "============================"
-end
-
-def list_checks
-  Intrigue::Ident::Http::CheckFactory.checks.map { |x| x.new.generate_checks("[uri]") }.concat(
-    Intrigue::Ident::Dns::CheckFactory.checks.map { |x| x.new.generate_checks }
-  ).concat(
-    Intrigue::Ident::Ftp::CheckFactory.checks.map { |x| x.new.generate_checks }
-  ).concat(
-    Intrigue::Ident::Mysql::CheckFactory.checks.map { |x| x.new.generate_checks }
-  ).concat(
-    Intrigue::Ident::Pop3::CheckFactory.checks.map { |x| x.new.generate_checks }
-  ).concat(
-    Intrigue::Ident::Redis::CheckFactory.checks.map { |x| x.new.generate_checks }
-  ).concat(
-    Intrigue::Ident::Smtp::CheckFactory.checks.map { |x| x.new.generate_checks }
-  ).concat(
-    Intrigue::Ident::Snmp::CheckFactory.checks.map { |x| x.new.generate_checks }
-  ).concat(
-    Intrigue::Ident::Ssh::CheckFactory.checks.map { |x| x.new.generate_checks }
-  ).concat(
-    Intrigue::Ident::Telnet::CheckFactory.checks.map { |x| x.new.generate_checks }
-  ).concat(
-    Intrigue::Ident::Imap::CheckFactory.checks.map { |x| x.new.generate_checks }
-  ).concat(
-    Intrigue::Ident::ElasticSearch::CheckFactory.checks.map { |x| x.new.generate_checks }
-  ).concat(
-    Intrigue::Ident::MongoDb::CheckFactory.checks.map { |x| x.new.generate_checks }
-  ).flatten
-end
-
-def main
-  begin
-    ###
-    ### Parse options
-    ###
-    opts = Slop.parse do |o|
-
-      # url input
-      o.string "-u", "--uri", "a uri to check (supported portocols: " +
-        "(dns, elasticsearch, ftp, http, https, imap, mongodb, mysql, pop3, redis, smtp, snmp, telnet) " +
-        "ex: http://intrigue.io"
-      o.string "-f", "--file", "a file of urls, one per line"
-
-      # export
-      #o.bool '--csv', 'export to csv'
-      o.bool "--json", "export to json"
-
-      # behavior
-      o.string "-i", "--include", "include checks from this directory (can be used multiple times)"
-      o.integer "-t", "--threads", "number of threads to use when checking a file (default: 3)"
-      o.bool "-v", "--vulnerabilities", "query intrigue.io api for top vulnerabilities"
-      o.bool "-c", "--content", "show content checks"
-      o.bool "-b", "--only-check-base-url", "only base url "
-      o.bool "-d", "--debug", "enable debug mode"
-      o.bool "-l", "--list-checks", "just list checks"
-
-      o.on "-h", "--help" do
-        puts o
-        exit
-      end
-
-      o.on "--version", "print the version" do
-        puts Ident::VERSION
-        exit
-      end
-    end
-  rescue Slop::MissingArgument => e
-    puts "Error! #{e}"
-    return
-  end
-
-  ###
-  ## include external checks
-  ###
-  if opts[:include]
-    # follow directory structure from ident
-    checks = Dir.glob("#{opts[:include]}/checks/*.rb")
-    checks += Dir.glob("#{opts[:include]}/checks/*/*.rb")
-    checks += Dir.glob("#{opts[:include]}/checks/*/*/*.rb")
-    puts "Requiring #{checks.count} files from include path: #{opts[:include]}" if opts[:debug]
-    checks.each do |p|
-      require p
-    end
-  end
-
-  if opts[:'list-checks']
-    puts "Fingerprint, Version Detection, Hide By Default, Issues, Vulnerability Inference, Tags"
-    list_checks.sort_by { |c| "#{c[:type]}" }.each do |c|
-      next unless c[:type] == "fingerprint"
-      out = ""
-      out << "#{c[:name]} #{c[:vendor]} #{c[:product]} #{c[:version]}".gsub(",", "") + ", "
-      out << "#{!c[:dynamic_version].nil?}, "
-      out << "#{c[:hide]}, "
-      out << "#{(c[:issues].join(" | ") if c[:issues]) || c[:issue]}, "
-      out << "#{c[:inference]}, "
-      #out << "#{c[:paths].join(" | ") if c[:paths]}, "
-      out << "#{c[:tags].join(" | ") if c[:tags]}"
-      puts out
-    end
-    return # so we don't hit the next gate
-  end
-
-  unless opts[:uri] || opts[:file]
-    puts "Error! At least one of --file, or --uri must be specified"
-    return
-  end
-
-  ## handle url input
-  if opts[:uri]
-    puts "Checking URL: #{opts[:uri]}" if opts[:debug]
-    check_single_uri(opts)
-  end
-
-  ## handle file input
-  if opts[:file]
-    puts "Checking File: #{opts[:file]}" if opts[:debug]
-    check_file_uris(opts)
-  end
-end
 
 main

--- a/util/list_paths.rb
+++ b/util/list_paths.rb
@@ -1,12 +1,4 @@
 #!/usr/bin/env ruby
 require_relative "../lib/ident"
-include Intrigue::Ident
-
-def list_checks
-  Intrigue::Ident::Http::CheckFactory.checks.map{|x| x.new.generate_checks("[uri]") }.flatten
-  #Intrigue::Ident::Ftp::CheckFactory.checks.map{|x| x.new.generate_checks.flatten
-  #Intrigue::Ident::Smtp::CheckFactory.checks.map{|x| x.new.generate_checks.flatten
-  #Intrigue::Ident::Snmp::CheckFactory.checks.map{|x| x.new.generate_checks.flatten
-end
-
-puts list_checks.map{|c| c[:paths] }.flatten.sort.uniq
+ident = Intrigue::Ident::Ident.new
+puts ident.list_checks.map{|c| c[:paths] }.flatten.sort.uniq


### PR DESCRIPTION
This commit cleans up the primary interface, and introduces two new methods that can be (are) used by core and the ident CLI: 

 - fingerprint_service: this method takes an ip and a port, and runs the appropriate checks 
 - fingerprint_uri: this method takes a uri, and turns it into an ip/port combination that can be sent to fingerprint_service 
 - list_checks: this method generates and lists all checks ... this is handy so we dont need to have clients directly interface with each protocol when generating a list of checks