### PR TITLE
vrealize operations manager + operations tenant app fingerprint

### DIFF
--- a/checks/http/fortinet.rb
+++ b/checks/http/fortinet.rb
@@ -54,6 +54,21 @@ module Check
           match_type: :content_body,
           match_content:  /FortiToken clock drift detected/i,
           paths: [ { path: "#{url}", follow_redirects: true } ],
+        },
+        {
+          type: "fingerprint",
+          category: "application",
+          tags: ["WAF","Networking"],
+          vendor: "Fortinet",
+          product:"FortiWeb",
+          references: [],
+          description:"response header",
+          match_type: :content_headers,
+          match_content:  /^server: fortiweb-.*$/i,
+          dynamic_version: lambda { |x|
+            _first_header_capture(x, /^server: fortiweb-(\d\.\d\.\d)$/i)
+          },
+          paths: [ { path: "#{url}", follow_redirects: true } ],
         }
       ]
     end

--- a/checks/http/vmware.rb
+++ b/checks/http/vmware.rb
@@ -57,7 +57,37 @@ class Vmware < Intrigue::Ident::Check::Base
         match_content:  /document.write\(\"<title>\"\ \+\ ID_VC_Welcome/,
         paths: [ { path: "#{url}", follow_redirects: true } ],
         inference: false
-      }
+      },
+      {
+        type: "fingerprint",
+        category: "application",
+        tags: ["Cloud", "Management"],
+        vendor: "VMware",
+        product: "vRealize Operations Manager",
+        description: "page title",
+        references: [],
+        version: nil,
+        match_type: :content_body,
+        match_content: /<title>vRealize Operations Manager<\/title>/,
+        hide: false,
+        paths: [ { path: "#{url}", follow_redirects: true } ],
+        inference: true
+      },
+      {
+        type: "fingerprint",
+        category: "application",
+        tags: ["Cloud", "Management"],
+        vendor: "VMware",
+        product: "vRealize Operations Tenant App",
+        description: "page title",
+        references: [],
+        version: nil,
+        match_type: :content_body,
+        match_content: /<title>vRealize Operations Tenant App<\/title>/,
+        hide: false,
+        paths: [ { path: "#{url}", follow_redirects: true } ],
+        inference: true
+      },
     ]
   end
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Ident
-  VERSION = "5.0.3"
+  VERSION = "5.0.4"
 end


### PR DESCRIPTION
Hi team,

Please find attached fingerprints the `vRealize Operations Manager` & `vRealize Operations Tenant App`. As both of these applications have unique web apps; I figured it was a better idea to split the two checks instead of creating one solely for `vRealize`. 

Edit: FortiWeb is included in this PR as well; includes a version extractor.

@shpendk 

Best regards,
Maxim