### PR TITLE
Bugfix random port https protocol

### DIFF
--- a/lib/ident.rb
+++ b/lib/ident.rb
@@ -373,7 +373,11 @@ module Intrigue
         if ident_matches
           return ident_matches # return right away if we a FP
         else
-          url = "http://#{ip_address_or_hostname}:#{port}"
+          url = if opts.key?(:ssl) && opts[:ssl] == true
+                  "https://#{ip_address_or_hostname}:#{port}"
+                else
+                  "http://#{ip_address_or_hostname}:#{port}"
+                end
           ident_matches = generate_http_requests_and_check(url, opts) || {}
 
           # if we didnt fail, pull out the FP and match to vulns

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Ident
-  VERSION = "5.0.4"
+  VERSION = "5.0.5"
 end

--- a/util/ident.rb
+++ b/util/ident.rb
@@ -218,7 +218,7 @@ def check_single_uri(opts)
 
   if uri = opts[:uri]
     if uri =~ /^http[s]?:\/\/.*$/
-      check_result = Intrigue::Ident::Ident.new.fingerprint_uri(uri)
+      check_result = Intrigue::Ident::Ident.new.fingerprint_uri(uri, {ssl: true})
       if @debug
         print_debug "Ran #{check_result["initial_checks"].first["count"]} initial checks against base URL"
         if !check_result["followon_checks"].empty?

--- a/util/ident.rb
+++ b/util/ident.rb
@@ -218,7 +218,8 @@ def check_single_uri(opts)
 
   if uri = opts[:uri]
     if uri =~ /^http[s]?:\/\/.*$/
-      check_result = Intrigue::Ident::Ident.new.fingerprint_uri(uri, {ssl: true})
+      use_ssl = uri =~ /^https:\/\/.*$/ ? true : false
+      check_result = Intrigue::Ident::Ident.new.fingerprint_uri(uri, { ssl: use_ssl })
       if @debug
         print_debug "Ran #{check_result["initial_checks"].first["count"]} initial checks against base URL"
         if !check_result["followon_checks"].empty?


### PR DESCRIPTION
This PR fixes a bug where ident would return `Generic Connection Reset (attempted HTTP connection)` when passing an *https* link with a non-standard port. For example, the following link would trigger a connection reset even though there's a webapp running on that port: `https://myawesomedomain:8443`.

The reason for this bug is that for non-common ports, we were automatically defaulting to `http` . Since the `fingerprint_uri` method conveniently has an `opts` parameter, I've solved it by passing `{ssl: true}` as an option, and then using `https` if its set. 