### PR TITLE
Bugfix use original scheme

### DIFF
--- a/lib/ident.rb
+++ b/lib/ident.rb
@@ -299,6 +299,10 @@ module Intrigue
         port = x.port || _service_to_port(x.scheme)
         hostname = x.host
 
+        # set scheme as option
+        opts[:scheme] = x.scheme
+        
+        # fingerprint it
         fingerprint_service(hostname, port, opts)
       end
 
@@ -373,7 +377,11 @@ module Intrigue
         if ident_matches
           return ident_matches # return right away if we a FP
         else
-          url = "http://#{ip_address_or_hostname}:#{port}"
+          # if scheme was provided by original uri use that, otherwise default to "http"
+          schema = opts.key?(:scheme) ? opts[:scheme] : "http"
+
+          # create url and fingerprint it
+          url = "#{schema}://#{ip_address_or_hostname}:#{port}"
           ident_matches = generate_http_requests_and_check(url, opts) || {}
 
           # if we didnt fail, pull out the FP and match to vulns

--- a/lib/ident.rb
+++ b/lib/ident.rb
@@ -378,10 +378,10 @@ module Intrigue
           return ident_matches # return right away if we a FP
         else
           # if scheme was provided by original uri use that, otherwise default to "http"
-          schema = opts.key?(:scheme) ? opts[:scheme] : "http"
+          scheme = opts.key?(:scheme) ? opts[:scheme] : "http"
 
           # create url and fingerprint it
-          url = "#{schema}://#{ip_address_or_hostname}:#{port}"
+          url = "#{scheme}://#{ip_address_or_hostname}:#{port}"
           ident_matches = generate_http_requests_and_check(url, opts) || {}
 
           # if we didnt fail, pull out the FP and match to vulns

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Ident
-  VERSION = "5.0.4"
+  VERSION = "5.0.5"
 end


### PR DESCRIPTION
This is a better fix for [https://github.com/intrigueio/intrigue-ident/pull/98](https://github.com/intrigueio/intrigue-ident/pull/98). Original PR comment:
```
This PR fixes a bug where ident would return "Generic Connection Reset (attempted HTTP connection)" when passing an https link with a non-standard port. For example, the following link would trigger a connection reset even though there's a webapp running on that port: https://myawesomedomain:8443.

The reason for this bug is that for non-common ports, we were automatically defaulting to http . Since the fingerprint_uri method conveniently has an opts parameter, I've solved it by passing {ssl: true} as an option, and then using https if its set.
```

This PR offers a better fix, by saving the original scheme in the `opts` hash when `fingerprint_uri` is called. Later, in `fingerprint_service` we check whether the original scheme is present and use it. We still default to `http` if no scheme is given, because `fingerprint_service` may be called from other places (i found at least one place) and hence there may not be an original scheme. 

ps: the variable `schema` is deliberately named wrong, to not interfere with possible variables named `scheme`. 