### PR TITLE
Custom tcp checks

### DIFF
--- a/checks/tcp/base.rb
+++ b/checks/tcp/base.rb
@@ -1,0 +1,16 @@
+module Intrigue
+  module Ident
+  module TcpCheck
+  class Base
+  
+    include Intrigue::Ident::BannerHelpers
+  
+    def self.inherited(base)
+      Intrigue::Ident::Tcp::CheckFactory.register(base)
+    end
+  
+  end
+  end
+  end
+  end
+  

--- a/checks/tcp/cisco_smart_install.rb
+++ b/checks/tcp/cisco_smart_install.rb
@@ -18,7 +18,8 @@ class CiscoSmartInstall < Intrigue::Ident::TcpCheck::Base
         match_content: /^\x00{3}\x04\x00{7}\x03\x00{3}\x08\x00{3}\x01\x00{4}$/i,
         description: "match via protocol hex string",
         hide: false,
-        inference: false
+        inference: false,
+        issue: 'cisco_smartinstall_cve_2018_0151'
       }
     ]
   end

--- a/checks/tcp/cisco_smart_install.rb
+++ b/checks/tcp/cisco_smart_install.rb
@@ -1,0 +1,28 @@
+module Intrigue
+module Ident
+module TcpCheck
+class CiscoSmartInstall < Intrigue::Ident::TcpCheck::Base
+  def generate_checks
+    [
+      {
+        type: "fingerprint",
+        category: "operating_system",
+        tags: ["Tcp", "Cisco"],
+        vendor: "Cisco",
+        product: "Smart Install",
+        references: [],
+        version: nil,
+        request_type: :hex,
+        request_content: "\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x08\x00\x00\x00\x01\x00\x00\x00\x00",
+        #match_type: :content_banner, we don't have a match_type because we can only match whatever we get in the response
+        match_content: /^\x00{3}\x04\x00{7}\x03\x00{3}\x08\x00{3}\x01\x00{4}$/i,
+        description: "match via protocol hex string",
+        hide: false,
+        inference: false
+      }
+    ]
+  end
+end
+end
+end
+end

--- a/lib/ident.rb
+++ b/lib/ident.rb
@@ -269,6 +269,19 @@ require_relative '../checks/smb/base'
 check_folder = File.expand_path('../checks/smb', File.dirname(__FILE__)) # get absolute directory
 Dir["#{check_folder}/*.rb"].each { |file| require_relative file }
 
+
+##################################
+# Load in custom tcp checks 
+##################################
+require_relative 'tcp/tcp'
+require_relative 'tcp/check_factory'
+require_relative '../checks/tcp/base'
+include Intrigue::Ident::Tcp
+
+# tcp fingerprints
+check_folder = File.expand_path('../checks/tcp', File.dirname(__FILE__)) # get absolute directory
+Dir["#{check_folder}/*.rb"].each { |file| require_relative file }
+
 ###
 ### End protocol requires
 ###
@@ -318,6 +331,8 @@ module Intrigue
           Intrigue::Ident::Amqp::CheckFactory.checks.map { |x| x.new.generate_checks }
         ).concat(
           Intrigue::Ident::Smb::CheckFactory.checks.map { |x| x.new.generate_checks }
+        ).concat(
+          Intrigue::Ident::Tcp::CheckFactory.checks.map { |x| x.new.generate_checks }
         ).flatten
       end
 
@@ -415,6 +430,13 @@ module Intrigue
         if port == 2083 || port =~ /^\d+2083$/
           ident_matches = generate_http_requests_and_check(ip_address_or_hostname, opts) || {}
         end
+
+        # if you want a custom tcp protocol to be scanned, enter them here
+        if port == 4786
+          ident_matches = generate_tcp_requests_and_check(ip_address_or_hostname, port) || {}
+        end
+
+
         ###
         ### But default to HTTP through each known port
         ###

--- a/lib/tcp/check_factory.rb
+++ b/lib/tcp/check_factory.rb
@@ -1,0 +1,24 @@
+module Intrigue
+module Ident
+module Tcp
+class CheckFactory
+
+  #
+  # Register a new handler
+  #
+  def self.register(klass)
+    @checks = [] unless @checks
+    @checks << klass if klass
+  end
+
+  #
+  # Provide the full list of checks
+  #
+  def self.checks
+    @checks
+  end
+
+end
+end
+end
+end

--- a/lib/tcp/content.rb
+++ b/lib/tcp/content.rb
@@ -1,0 +1,13 @@
+module Intrigue
+  module Ident
+    module Tcp
+      module Content
+
+      def _banner(content)
+        content["details"]["banner"]
+      end
+
+    end
+  end
+end
+end

--- a/lib/tcp/tcp.rb
+++ b/lib/tcp/tcp.rb
@@ -1,0 +1,87 @@
+module Intrigue
+  module Ident
+    module Tcp
+      include Intrigue::Ident::SimpleSocket
+
+      def generate_tcp_requests_and_check(ip, port, debug = false)
+
+        results = []
+        checks = []
+        if Intrigue::Ident::Tcp::CheckFactory.checks != nil
+          # generate the checks
+          checks = Intrigue::Ident::Tcp::CheckFactory.checks.map {
+            |x|
+            x.new.generate_checks
+          }.compact.flatten
+        end
+        
+        checks.each do |check|
+          # mak the request according to the type
+          if check[:request_type] == :hex
+            res = send_hex_request(ip, port, check[:request_content])
+          elsif check[:request_type] == :plain
+            res = send_plain_request(ip, port, check[:request_content])
+          else
+            raise "Unknown request type"
+          end
+
+          # match the response
+          res = res.unpack("U*").map{|c|c.chr}.join
+          if res =~ check[:match_content]
+            # wee, we found something
+            results << _construct_match_response(check, res)
+          end
+        end
+        { "fingerprint" => results.uniq.compact, "banner" => "", "content" => [] }
+      end
+
+      private
+
+      def send_hex_request(ip, port, data, timeout = 3)
+        if socket = connect_tcp(ip, port, timeout)
+          # first try to read something in case something comes back
+          #puts "Attempting to read data first."
+          out = "" 
+          begin
+            out =+ socket.readpartial(24576, timeout: timeout)
+          rescue Errno::EHOSTUNREACH => e
+            _logg "Error while reading! Host Unreachable."
+            return
+          rescue Errno::ECONNRESET => e
+            _logg "Error while reading!"
+          rescue Socketry::TimeoutError
+            _logg "Error while reading! Timeout."
+          end
+
+          # now send our data
+          _logg "Writing request data."
+          socket.writepartial(data)
+
+          #and read the response
+          _logg "Reading response."
+          begin
+            out =+ socket.readpartial(24576, timeout: timeout)
+          rescue Errno::EHOSTUNREACH => e
+            _logg "Error while reading! Host Unreachable."
+            return
+          rescue Errno::ECONNRESET => e
+            _logg "Error while reading!"
+          rescue Socketry::TimeoutError
+            _logg "Error while reading! Timeout."
+          end
+        else
+          out = nil
+        end
+
+        "#{out}".encode("UTF-8", invalid: :replace, undef: :replace, replace: "?")
+      end
+
+
+      def _logg(msg, debug = false)
+        if debug
+          puts "DEBUG: #{msg}"
+        end
+      end
+    end
+  end
+end

--- a/lib/tcp/tcp.rb
+++ b/lib/tcp/tcp.rb
@@ -38,6 +38,11 @@ module Intrigue
       private
 
       def send_hex_request(ip, port, data, timeout = 3)
+        # TODO: do we need to do anything different to send in hex vs plain?
+        send_plain_request(ip, port, data, timeout)
+      end
+
+      def send_plain_request(ip, port, data, timeout = 3)
         if socket = connect_tcp(ip, port, timeout)
           # first try to read something in case something comes back
           #puts "Attempting to read data first."

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Ident
-  VERSION = "5.2.1"
+  VERSION = "5.2.2"
 end


### PR DESCRIPTION
This change supports fingerprints that go over tcp. In the fingerprint one can specify the hex (or plain) string to be sent and what to match in the response. 