### PR TITLE
Adds changes to ip.rb, ident.rb, creating new oracle.rb ip check

### DIFF
--- a/checks/ip/oracle.rb
+++ b/checks/ip/oracle.rb
@@ -14,7 +14,6 @@ module Intrigue
               references: [
                 'https://www.oracle.com/middleware/technologies/weblogic.html'
               ],
-              version: nil,
               request_type: :plain,
               protocol: :tcp,
               request_content: "t3 12.2.1\nAS:255\nHL:19\nMS:10000000\nPU:t3://us-l-breens:7001\n\n",
@@ -22,10 +21,7 @@ module Intrigue
               match_content: /^HELO:.*$/i,
               dynamic_version: lambda { |x|
                 _first_banner_capture(x, /^HELO:(.*)\.false.*$/i)
-              },
-              hide: false,
-              inference: false,
-              issue: 'oracle_weblogicserver_cve_2021_2109'
+            }
             }
           ]
         end

--- a/checks/ip/oracle.rb
+++ b/checks/ip/oracle.rb
@@ -1,0 +1,35 @@
+module Intrigue
+  module Ident
+    module TcpCheck
+      class Oracle < Intrigue::Ident::IpCheck::Base
+        def generate_checks
+          [
+            {
+              type: 'fingerprint',
+              category: 'application',
+              tags: %w[Tcp Oracle],
+              vendor: 'Oracle',
+              product: 'WebLogic Server',
+              description: 'match via protocol response string',
+              references: [
+                'https://www.oracle.com/middleware/technologies/weblogic.html'
+              ],
+              version: nil,
+              request_type: :plain,
+              protocol: :tcp,
+              request_content: "t3 12.2.1\nAS:255\nHL:19\nMS:10000000\nPU:t3://us-l-breens:7001\n\n",
+              # match_type: :content_banner, we don't have a match_type because we can only match whatever we get in the response
+              match_content: /^HELO:.*$/i,
+              dynamic_version: lambda { |x|
+                _first_banner_capture(x, /^HELO:(.*)\.false.*$/i)
+              },
+              hide: false,
+              inference: false,
+              issue: 'oracle_weblogicserver_cve_2021_2109'
+            }
+          ]
+        end
+      end
+    end
+  end
+end

--- a/lib/ident.rb
+++ b/lib/ident.rb
@@ -432,7 +432,7 @@ module Intrigue
         end
 
         # if you want a custom tcp protocol to be scanned, enter them here
-        if port == 4786 || port == 3389
+        if port == 4786 || port == 3389 || port == 7001
           ident_matches = generate_ip_requests_and_check(ip_address_or_hostname, port) || {}
         end
 

--- a/lib/ip/ip.rb
+++ b/lib/ip/ip.rb
@@ -24,11 +24,15 @@ module Intrigue
           else
             raise "Unknown request type"
           end
-
+          details = {
+            "details" => {
+              "banner" => res,
+            },
+          }
           # match the response
           if res =~ check[:match_content]
             # wee, we found something
-            results << _construct_match_response(check, res)
+            results << _construct_match_response(check, details)
           end
         end
         { "fingerprint" => results.uniq.compact, "banner" => "", "content" => [] }


### PR DESCRIPTION
Adds details hash to `ip.rb` in order to allow banner capture to behave like the other checks.

Adds 7001 port to `ident.rb`.

Creating a new `oracle.rb` IP check, which makes the Oracle Weblogic Server fingerprintable (also returns a version number).

Kudos to Duarte for helping with figuring out the banner capturing functionality.