### PR TITLE
Changes tag filtering behaviour.

### DIFF
--- a/lib/http/check_factory.rb
+++ b/lib/http/check_factory.rb
@@ -23,27 +23,19 @@ module Intrigue
         def self.generate_initial_checks(url, opts = {})
           checks_to_return = @checks.map { |x| x.new.generate_checks(url.to_s) }.flatten.compact
 
-          # if tags were provided, filter by them
-          checks_to_return = filter_by_tags(checks_to_return, opts)
-
           # if we're not in noisy mode, filter checks that have require_* conditions
-          unless opts[:noisy]
-            checks_to_return = checks_to_return.select do |x|
-              x[:require_product].nil? && x[:require_vendor].nil? && x[:require_vendor_product].nil? && x
-            end
-          end
+          return checks_to_return if opts[:noisy]
 
-          checks_to_return
+          checks_to_return.select do |x|
+            x[:require_product].nil? && x[:require_vendor].nil? && x[:require_vendor_product].nil? && x
+          end
         end
 
         #
         # Provide checks given a vendor
         #
-        def self.generate_checks_for_vendor(url, vendor, opts = {})
+        def self.generate_checks_for_vendor(url, vendor, _opts = {})
           checks_to_return = @checks.map { |x| x.new.generate_checks(url.to_s) }.flatten.compact
-
-          # if tags were provided, filter by them
-          checks_to_return = filter_by_tags(checks_to_return, opts)
 
           checks_to_return.select do |x|
             x[:require_vendor] == vendor.to_s
@@ -53,11 +45,8 @@ module Intrigue
         #
         # Provide checks givene a product
         #
-        def self.generate_checks_for_product(url, product, opts = {})
+        def self.generate_checks_for_product(url, product, _opts = {})
           checks_to_return = @checks.map { |x| x.new.generate_checks(url.to_s) }.flatten.compact
-
-          # if tags were provided, filter by them
-          checks_to_return = filter_by_tags(checks_to_return, opts)
 
           checks_to_return.select do |x|
             x[:require_product] == product.to_s
@@ -67,11 +56,8 @@ module Intrigue
         #
         # Provide checks givene a vendor product
         #
-        def self.generate_checks_for_vendor_product(url, vendor, product, opts = {})
+        def self.generate_checks_for_vendor_product(url, vendor, product, _opts = {})
           checks_to_return = @checks.map { |x| x.new.generate_checks(url.to_s) }.flatten.compact
-
-          # if tags were provided, filter by them
-          checks_to_return = filter_by_tags(checks_to_return, opts)
 
           checks_to_return.select do |x|
             x[:require_vendor_product] == "#{vendor}_#{product}".downcase.gsub(' ', '_')
@@ -80,9 +66,36 @@ module Intrigue
 
         def self.filter_by_tags(checks, opts)
           if opts[:checks_with_tag] && !opts[:checks_with_tag].empty?
-            checks = checks.reject { |x| x[:tags].nil? }
             checks = checks.reject do |x|
-              (x[:tags].map(&:upcase) & opts[:checks_with_tag].map(&:upcase)).empty?
+              (x[:tags].nil? || x[:tags].map(&:upcase) & opts[:checks_with_tag].map(&:upcase)).empty?
+            end
+          end
+          checks
+        end
+
+        # This function will be deleted once we have normalized the hashes. Some work around that has been done
+        # on the redirect branch.
+        def self.filter_by_tags_post_run_initial_results(checks, opts)
+          if opts[:checks_with_tag] && !opts[:checks_with_tag].empty?
+            checks = checks.reject do |x|
+              if x['tags'].nil?
+                true
+              else
+                (x['tags'].map(&:upcase) & opts[:checks_with_tag].map(&:upcase)).empty?
+              end
+            end
+          end
+          checks
+        end
+
+        def self.filter_by_tags_post_run(checks, opts)
+          if opts[:checks_with_tag] && !opts[:checks_with_tag].empty?
+            checks = checks.reject do |x|
+              if x[:tags].nil?
+                true
+              else
+                (x[:tags].map(&:upcase) & opts[:checks_with_tag].map(&:upcase)).empty?
+              end
             end
           end
           checks

--- a/lib/http/http.rb
+++ b/lib/http/http.rb
@@ -104,6 +104,18 @@ module Intrigue
         # allow us to only select the base path (speeds things up)
         grouped_followon_checks = grouped_followon_checks.select { |x, _y| x == url } if only_base
 
+        # filter by tag if tags are set.
+        if opts[:checks_with_tag] && !opts[:checks_with_tag].empty?
+          initial_results['fingerprint'] =
+            Intrigue::Ident::Http::CheckFactory.filter_by_tags_post_run_initial_results(
+              initial_results['fingerprint'], opts
+            )
+
+          grouped_followon_checks.each do |x, fingerprint|
+            grouped_followon_checks[x] = Intrigue::Ident::Http::CheckFactory.filter_by_tags_post_run(fingerprint, opts)
+          end
+        end
+
         ### OKAY NOW WE HAVE a set of output that we can run product-specific checks on, run'm
         followon_results = if grouped_followon_checks
                              run_grouped_http_checks(url, grouped_followon_checks, dom_checks, debug)
@@ -153,6 +165,11 @@ module Intrigue
             next
           end
 
+          # this block should be moved to a sanitise uri function
+          # if the user adds too many // to the url this will remove them
+          target_url = URI.parse(target_url)
+          target_url.path.squeeze!('/')
+          #
           # get the response using a normal http request
           puts "Getting #{target_url}" if debug
           response_hash = ident_http_request :get, target_url.to_s, nil, {}, nil, follow_redirects

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Ident
-  VERSION = "5.2.7"
+  VERSION = "5.2.8"
 end


### PR DESCRIPTION
Every URL should now be checked as if tags were not used.
Filtering will happen post initial run.

This change should now allow the default URLs to be executed and only after will the filtering be applied.

At the moment there is a bit of duplication going on due to some of the Hash being accessed through hash['access'] and other through hash[:access]. There's already work started on another branch which will allow us to remove one of them.